### PR TITLE
Fix export to include the actual nodes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 * text=auto eol=lf
 
 # Only include /assets/complex_shape_creation/* for download from the asset store.
-# *                                 export-ignore
+*                                 export-ignore
 
 /addons                          -export-ignore
 /addons/complex_shape_creation   -export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 * text=auto eol=lf
 
 # Only include /assets/complex_shape_creation/* for download from the asset store.
-*                                 export-ignore
+*                                  export-ignore
 
-/addons                          -export-ignore
-/addons/complex_shape_creation   -export-ignore
-/addons/complex_shape_creation/* -export-ignore
+/addons                           -export-ignore
+/addons/complex_shape_creation    -export-ignore
+/addons/complex_shape_creation/** -export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 * text=auto eol=lf
 
 # Only include /assets/complex_shape_creation/* for download from the asset store.
-*                             export-ignore
+# *                                 export-ignore
 
-/addons                       -export-ignore
+/addons                          -export-ignore
 /addons/complex_shape_creation   -export-ignore
 /addons/complex_shape_creation/* -export-ignore


### PR DESCRIPTION
The issue was that `*` only captures files in the current folder, `**` must be used in order to capture all files in sub folders as well.