### PR TITLE
Add Beginnings of `RegularGeometry`

### DIFF
--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -42,12 +42,18 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 	var next_point : Vector2
 	var point_after_final : Vector2
 	var previous_point : Vector2
-	if start_index == 0 and length == original_array_size:
-		point_after_final = points[start_index]
-		previous_point = points[start_index - points_per_corner]
+	if start_index == 0:
+		if length == original_array_size:
+			previous_point = points[original_array_size + size_increase - points_per_corner]
+		else:
+			previous_point = points[original_array_size + size_increase - 1]
 	else:
-		point_after_final = points[start_index + length * points_per_corner - (original_array_size + size_increase)]
 		previous_point = points[start_index - 1]
+
+	if start_index + length == original_array_size:
+		point_after_final = points[0]
+	else:
+		point_after_final = points[start_index + length * points_per_corner - points.size()]
 	
 	for i in length:
 		if i + 1 == length:

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -1,0 +1,94 @@
+class_name RegularGeometry2D
+
+## Holds methods for creating and modifying shapes.
+
+static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
+	start_index := 0, length := -1, original_array_size := 0) -> void:
+	# argument prep 
+	var corner_size_squared := corner_size ** 2
+	var points_per_corner := corner_smoothness + 1
+	var resize_array := false
+	if original_array_size <= 0:
+		resize_array = true
+		original_array_size = points.size()
+	if length < 0:
+		length = original_array_size - start_index
+	if corner_smoothness == 0:
+		corner_smoothness = 32 / points.size()
+	
+	assert(points.size() >= 3, "param 'points' must have at least 3 points.")
+	assert(corner_size >= 0, "param 'corner_size' must be 0 or greater.")
+	assert(corner_smoothness >= 0, "param 'corner_smoothness' must be 0 or greater.")
+	assert(start_index >= 0, "param 'start_index' must be 0 or greater.")
+	assert(start_index + length <= original_array_size, "sum of param 'start_index' & param 'length' must not be greater than the original size of the array (param 'original_array_size', or if 0, size of param 'points').")
+
+	# resizing and spacing
+	var size_increase := SizeIncrease.add_rounded_corners(length, corner_smoothness)
+	if resize_array:
+		points.resize(original_array_size + size_increase)
+		for i in (original_array_size - start_index - length):
+			points[-i - 1] = points[-i - 1 - size_increase]
+	else:
+		assert(original_array_size + size_increase <= points.size(), "The function is set to use the empty space in param 'points' but it is too small.")
+		for i in (original_array_size - start_index - length):
+			points[original_array_size - i - 1 + size_increase]= points[original_array_size - i - 1]
+
+	for i in length:
+		var index := length - i - 1
+		points[start_index + index * points_per_corner] = points[index + start_index]
+
+	# pre-loop prep and looping
+	var current_point := points[start_index]
+	var next_point : Vector2
+	var point_after_final : Vector2
+	var previous_point : Vector2
+	if start_index == 0 and length == original_array_size:
+		point_after_final = points[start_index]
+		previous_point = points[start_index - points_per_corner]
+	else:
+		point_after_final = points[start_index + length * points_per_corner - (original_array_size + size_increase)]
+		previous_point = points[start_index - 1]
+	
+	for i in length:
+		if i + 1 == length:
+			next_point = point_after_final
+		else:
+			next_point = points[start_index + (i + 1) * points_per_corner]
+		
+		# creating corner
+		var starting_slope := (current_point - previous_point)
+		var ending_slope := (current_point - next_point)
+		var starting_point : Vector2
+		var ending_point : Vector2
+		if starting_slope.length_squared() / 4 < corner_size_squared:
+			starting_point = current_point - starting_slope / 2.001
+		else:
+			starting_point = current_point - starting_slope.normalized() * corner_size
+		
+		if ending_slope.length_squared() / 4 < corner_size_squared:
+			ending_point = current_point - ending_slope / 2.001
+		else:
+			ending_point = current_point - ending_slope.normalized() * corner_size
+
+		points[start_index + i * points_per_corner] = starting_point
+		points[start_index + i * points_per_corner + points_per_corner - 1] = ending_point
+		# sub_i is initialized with a value of 1 as a corner_smoothness of 1 has no in-between points.
+		var sub_i := 1
+		while sub_i < corner_smoothness:
+			var t_value := sub_i / (corner_smoothness as float)
+			points[start_index + i * points_per_corner + sub_i] = _quadratic_bezier_interpolate(starting_point, current_point, ending_point, t_value)
+			sub_i += 1
+		
+		# end, prep for next loop.
+		previous_point = current_point
+		current_point = next_point
+
+static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
+	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
+
+## sub class that designates how much each method expands the array.
+class SizeIncrease:
+	static func add_rounded_corners(length : int, corner_smoothness : int) -> int:
+		assert(length >= 0, "param 'length' must be positive.")
+		assert(corner_smoothness > 0, "param 'corner_smoothness' must be positive.")
+		return length * (corner_smoothness + 1) - length

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -1,7 +1,18 @@
+extends Object
 class_name RegularGeometry2D
 
 ## Holds methods for creating and modifying shapes.
 
+func _init():
+	printerr("This class is meant to be a singleton, and cannot be instantiated")
+	self.free()
+
+## Modifies [param points] so that the shape it represents have rounded corners. The method uses quadratic Bézier curves for the corners.
+## [br][br][param corner_size] determines how long each corner is, from the original point to at most half the side length.
+## [param corner_smoothness] determines how many [b]lines[/b] are in each corner.
+## [br][br][param start_index] & [param length] can be used to specify only part of the shape should be rounded.
+## [param original_array_size], when used, indicates that the array has already been resized, so the method should add points into the empty space.
+## This parameter specifies the part of the array that is currently used.
 static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
 	start_index := 0, length := -1, original_array_size := 0) -> void:
 	# argument prep 
@@ -94,6 +105,15 @@ static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, en
 
 ## sub class that designates how much each method expands the array.
 class SizeIncrease:
+	extends Object
+
+	func _init():
+		printerr("This class is meant to be a singleton, and cannot be instantiated")
+		self.free()
+
+	## Designates how much [method RegularGeometry2D.add_rounded_corners] expands the array.
+	## [br][br][param length] specifies many points are to be converted into rounded corners.
+	## [param corner_smoothness] specifies how many lines are in each corner.
 	static func add_rounded_corners(length : int, corner_smoothness : int) -> int:
 		assert(length >= 0, "param 'length' must be positive.")
 		assert(corner_smoothness > 0, "param 'corner_smoothness' must be positive.")

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -77,7 +77,7 @@ func test_add_rounded_corners__full_shape_with_resizing__expected_shape():
 	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, 4)
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, true, 4)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -90,7 +90,7 @@ func test_add_rounded_corners__partial_shape_with_resizing__expected_shape(p=use
 	var expected_shape : PackedVector2Array = p[2]
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, 4)
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -105,6 +105,18 @@ func test_add_rounded_corners__partial_shape_with_resizing_and_extra_empties_exp
 	expected_shape.resize(expected_shape.size() + extra_empty_spaces_amount)
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, 4)
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__non_limited_ending_slopes__expected_result():
+	const oversized_corner_size := 10
+	const sample_corner_smoothness := 1
+	const sample_start_index := 2
+	const sample_length := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2.UP]
+	var expected_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, 1), Vector2(1, 1)]
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, oversized_corner_size, sample_corner_smoothness, sample_start_index, sample_length, false)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -1,0 +1,110 @@
+extends GutTest
+
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s | %s)" % [c1, c2])
+		return
+	
+	var has_failed := false
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
+			has_failed = true
+
+	if not has_failed:
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+
+var various_shapes_with_corner_smoothness := [
+	[1, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],
+	[3, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],
+	[3, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2(0.75, 1), Vector2(0.75, 1)]],
+]
+func test_add_rounded_corners__various_shapes_with_0_corner_size__expected_shape(p=use_parameters(various_shapes_with_corner_smoothness)):
+	var corner_smoothness : int = p[0]
+	var shape : PackedVector2Array = p[1]
+	var original := PackedVector2Array(shape)
+	var expected_size := shape.size() * (corner_smoothness + 1)
+
+	RegularGeometry2D.add_rounded_corners(shape, 0, corner_smoothness)
+
+	assert_eq(shape.size(), expected_size, "Size of modified array should be %s but was %s" % [expected_size, shape.size()])
+	for i in original.size():
+		for i2 in (corner_smoothness + 1):
+			assert_almost_eq(shape[i * (corner_smoothness + 1) + i2], original[i], Vector2.ONE * 0.001)
+
+func test_add_rounded_corners__oversized_corner_size__corner_size_limited():
+	const sample_corner_smoothness := 2
+	const oversized_corner_size := 32.432
+	var shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	const expected_shape : PackedVector2Array = [
+		Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN,
+		Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT,
+		Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP,
+		Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT
+	]
+
+	RegularGeometry2D.add_rounded_corners(shape, oversized_corner_size, sample_corner_smoothness)
+
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.01)
+
+var shapes_with_various_starts_and_lengths := [
+	[0, 4, [Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN, Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT, Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT]],
+	[0, 1, [Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN, Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]],
+	[1, 2, [Vector2(1, 1), Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT, Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2(1, -1)]],
+	[2, -1, [Vector2(1, 1), Vector2(-1, 1), Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT]]
+]
+func test_add_rounded_corners___custom_start_and_length__expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__full_shape_with_resizing__expected_shape():
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	const expected_shape : PackedVector2Array = [
+		Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN,
+		Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT,
+		Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP,
+		Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT
+	]
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__partial_shape_with_resizing__expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__partial_shape_with_resizing_and_extra_empties_expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const extra_empty_spaces_amount := 5
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+	expected_shape.resize(expected_shape.size() + extra_empty_spaces_amount)
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)


### PR DESCRIPTION
Adds the classes `RegularGeometry` and `RegularGeometry.SizeIncrease`, both of which are meant to be static classes and cannot be instantiated. The methods in these classes are meant to be more complex versions of their equivalents in the nodes (for instance, operating on only parts of a points array).

The only method currently implemented is `add_rounded_corners`. This is to help solve other issues (specifically #52). As such, this isn't the complete implementation, so things like c# support aren't implemented yet.