### PR TITLE
Add `apply_transformation`, Directly Editing Points

### DIFF
--- a/addons/complex_shape_creation/MethodName.cs
+++ b/addons/complex_shape_creation/MethodName.cs
@@ -20,4 +20,5 @@ public static class MethodName
     public static readonly StringName GetStarVertices = new("get_star_vertices");
     public static readonly StringName WidenPolyline = new("_widen_polyline_result");
     public static readonly StringName WidenMultiline = new("_widen_multiline_result");
+    public static readonly StringName ApplyTransform = new("apply_transform");
 }

--- a/addons/complex_shape_creation/MethodName.cs
+++ b/addons/complex_shape_creation/MethodName.cs
@@ -20,5 +20,5 @@ public static class MethodName
     public static readonly StringName GetStarVertices = new("get_star_vertices");
     public static readonly StringName WidenPolyline = new("_widen_polyline_result");
     public static readonly StringName WidenMultiline = new("_widen_multiline_result");
-    public static readonly StringName ApplyTransform = new("apply_transform");
+    public static readonly StringName ApplyTransformation = new("apply_transformation");
 }

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
@@ -104,7 +104,7 @@ public class RegularCollisionPolygon2D
         set => Instance.Scale = value;
     }
     
-    /// <inheritdoc cref="RegularPolygon2D.ApplyTransform(float, float, bool, bool)"/>
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransformation(float, float, bool, bool)"/>
     /// <summary>
     /// Transforms <see cref="CollisionShape2D.Shape"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
     /// </summary>
@@ -116,7 +116,7 @@ public class RegularCollisionPolygon2D
     /// </remarks>
     /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
     /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
-    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>Creates and wraps a <see cref="CollisionShape2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
@@ -103,6 +103,20 @@ public class RegularCollisionPolygon2D
         get => Instance.Scale;
         set => Instance.Scale = value;
     }
+    
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransform(float, float, bool, bool)"/>
+    /// <summary>
+    /// Transforms <see cref="CollisionShape2D.Shape"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method modifies the existing <see cref="CollisionShape2D.Shape"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="CollisionShape2D.Shape"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>Creates and wraps a <see cref="CollisionShape2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -28,6 +28,40 @@ var size : float = 10:
 		size = value
 		queue_regenerate()
 
+func apply_size_scale(scale : float) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	
+	_queue_status = _BLOCK_QUEUE
+	size *= scale
+	inner_size *= scale
+	_queue_status = _NOT_QUEUED
+
+	var current = shape
+	if current == null:
+		regenerate()
+		return
+
+	if current is CircleShape2D:
+		current.radius *= scale
+		return
+	if current is RectangleShape2D:
+		current.size *= scale
+		return
+	if current is SegmentShape2D:
+		current.a *= size
+		current.b *= size
+		return
+
+	var transform = Transform2D(0, Vector2.ONE * scale, 0, Vector2.ZERO)
+	if current is ConvexPolygonShape2D:
+		current.points *= transform
+		return
+	if current is ConcavePolygonShape2D:
+		current.segments *= transform
+		return
+	
+	printerr("unexpected shape found: (%s)" % current)
+
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):
@@ -41,6 +75,37 @@ var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
 		queue_regenerate()
+
+func rotate_shape(radian : float) -> void:
+	var current = shape
+	_queue_status = _BLOCK_QUEUE
+	offset_rotation += radian
+	_queue_status = _NOT_QUEUED
+	
+	if current == null:
+		regenerate()
+		return
+
+	if current is CircleShape2D:
+		return
+	
+	if current is RectangleShape2D:
+		regenerate()
+		return
+
+	var transform := Transform2D(radian, Vector2.ONE, 0, Vector2.ZERO)
+	if current is SegmentShape2D:
+		current.a *= transform
+		current.b *= transform
+		return
+	if current is ConvexPolygonShape2D:
+		current.points *= transform
+		return
+	if current is ConcavePolygonShape2D:
+		current.segments *= transform
+		return
+	
+	printerr("unexpected shape found: (%s)" % current)
 
 @export_group("complex")
 

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -47,9 +47,10 @@ var offset_rotation : float = 0:
 ## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
+## If these values are false, their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
 ## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
-func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
+func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE
 	offset_rotation += rotation

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -150,7 +150,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 			shape.segments = segments
 			return 
 			
-		# TODO: Should be possible, but requires modification of apply_transform that I don't want to do.
+		# TODO: Should be possible, but requires modification of apply_transformation that I don't want to do.
 		if scale_width != scale_corner_size and has_rounded_corners:
 			regenerate()
 			return

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -107,6 +107,194 @@ func rotate_shape(radian : float) -> void:
 	
 	printerr("unexpected shape found: (%s)" % current)
 
+func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	_queue_status = _BLOCK_QUEUE
+	offset_rotation += rotation
+	size *= scale
+	inner_size *= scale
+	if scale_width:
+		width *= scale
+
+	if scale_corner_size:
+		corner_size *= scale
+
+	_queue_status = _NOT_QUEUED
+	
+	if not scale_width and \
+		(width >= size and width < size / scale
+		or width < size and width >= size / scale):
+		regenerate()
+		return
+	
+	var is_star_shape := not is_zero_approx(inner_size)
+	var is_line := is_star_shape and vertices_count == 1 or not is_star_shape and vertices_count == 2
+	var has_rounded_corners := not is_zero_approx(corner_size)
+	var points_per_corner := 0
+	if has_rounded_corners:
+		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / vertices_count 
+	points_per_corner += 1
+
+	
+	# cares about scale_width
+	# unaffected by corner_size
+	if shape is CircleShape2D:
+		shape.radius *= scale
+		return
+
+	# cares about scale_width, corner_size, everything that isn't scale
+	if shape is RectangleShape2D:
+		if not is_zero_approx(rotation):
+			regenerate()
+			return
+
+		if not scale_width and is_line:
+			if is_zero_approx(sin(offset_rotation)):
+				shape.size.y *= scale
+				return
+			shape.size.x *= scale
+			return
+		shape.size *= scale
+		return
+	
+	# scale_width can't even effect this
+	if shape is SegmentShape2D:
+		var transform := Transform2D(-rotation, Vector2.ONE * scale, 0, Vector2.ZERO)
+		shape.a *= transform
+		shape.b *= transform
+		return
+	
+	if shape is ConvexPolygonShape2D:
+		var points : PackedVector2Array = shape.points
+		if not scale_width and is_line:
+			assert(points.size() == 4)
+			var slope1 := (points[0] - (points[0] - points[1]) / 2) * (scale - 1)
+			var slope2 := (points[3] - (points[0] - points[1]) / 2) * (scale - 1)
+			var transform := Transform2D(-rotation, Vector2.ONE, 0, Vector2.ZERO)
+			points[0] = (points[0] + slope1) * transform
+			points[1] = (points[1] + slope1) * transform
+			points[2] = (points[2] + slope2) * transform
+			points[3] = (points[3] + slope2) * transform
+			shape.points = points
+			return
+
+		RegularGeometry2D.apply_transformation(points, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
+		shape.points = points
+		return
+
+	if not shape is ConcavePolygonShape2D:
+		printerr("unexpected shape found: (%s)" % shape)
+		return
+
+	# requires special care for scale if it forms a line.
+	var segments : PackedVector2Array = shape.segments
+	if is_line:
+		if is_zero_approx(width):
+			if scale_corner_size and has_rounded_corners:
+				RegularGeometry2D.apply_transformation(segments, rotation, scale)
+				shape.segments = segments
+				return 
+			
+			segments[0] *= scale
+			segments[-1] *= scale
+			RegularGeometry2D.apply_transformation(segments, rotation, 1)
+			shape.segments = segments
+			return
+
+		
+		if scale_width and (scale_corner_size or not has_rounded_corners):
+			RegularGeometry2D.apply_transformation(segments, rotation, scale)
+			shape.segments = segments
+			return 
+			
+		# TODO: Should be possible, but requires modification of apply_transform that I don't want to do.
+		if scale_width != scale_corner_size and has_rounded_corners:
+			regenerate()
+			return
+
+		RegularGeometry2D.apply_transformation(segments, rotation, 1)
+
+		# extend segments
+		if not has_rounded_corners:
+			# point 1
+			var slope := (segments[0] - segments[1]) * (scale - 1)
+			var point := segments[0] + slope
+			segments[0] = point
+			segments[7] = point
+
+			point = segments[5] + slope
+			segments[5] = point
+			segments[6] = point
+
+			# point 2
+			slope = (segments[9] - segments[8]) * (scale - 1)
+			point = segments[9] + slope
+			segments[9] = point
+			segments[10] = point
+
+			point = segments[11] + slope
+			segments[11] = point
+			segments[12] = point
+		else:
+			# point 1
+			var slope := (segments[0] - (segments[-1] - segments[-2]) / 2) * (scale - 1)
+			var point := segments[0] + slope
+			segments[0] = point
+			segments[-1] = point
+
+			point = segments[-2] + slope
+			segments[-2] = point
+			segments[-3] = point
+
+			# point 2
+			var index := segments.size() / 2
+			slope = (segments[index] - (segments[index - 1] - segments[index - 2]) / 2) * (scale - 1)
+			point = segments[index] + slope
+			segments[index] = point
+			segments[index - 1] = point
+
+			point = segments[index - 2] + slope
+			segments[index - 2] = point
+			segments[index - 3] = point
+
+		shape.segments = segments
+		return
+	
+	var is_ringed_shape := 0 < width and width < size
+	var offset_points := _uses_drawn_arc() and is_ringed_shape
+	# TODO: Again, I don't want to change apply_transformation to make this work.
+	if is_ringed_shape and not _uses_drawn_arc():
+		regenerate()
+		return
+
+	var segment_size := segments.size()
+	for i in segment_size / 2 - 1:
+		segments[i + 1] = segments[i * 2 + 1]
+	segments.resize(segment_size / 2)
+
+	if offset_points:
+		var temp := segments[-1]
+		for i in segments.size() - 1:
+			segments[i - 1] = segments[i]
+		segments[-2] = temp
+
+	RegularGeometry2D.apply_transformation(segments, rotation, scale, is_ringed_shape, points_per_corner, scale_width, scale_corner_size)
+
+	if offset_points:
+		var temp := segments[0]
+		for i in segments.size() - 1:
+			segments[-i] = segments[-i - 1] 
+		segments[1] = temp
+
+	segments.resize(segment_size)
+	segments[-1] = segments[0]
+	for i in segment_size / 2 - 1:
+		var point := segments[segment_size / 2 - i - 1]
+		segments[-i * 2 - 2] = point
+		segments[-i * 2 - 3] = point
+
+	shape.segments = segments
+
 @export_group("complex")
 
 ## The length of the inner vertices between each normal vertices to the center of the shape. If set to [code]0[/code], it is ignored.

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -28,40 +28,6 @@ var size : float = 10:
 		size = value
 		queue_regenerate()
 
-func apply_size_scale(scale : float) -> void:
-	assert(scale > 0, "param 'scale' should be positive.")
-	
-	_queue_status = _BLOCK_QUEUE
-	size *= scale
-	inner_size *= scale
-	_queue_status = _NOT_QUEUED
-
-	var current = shape
-	if current == null:
-		regenerate()
-		return
-
-	if current is CircleShape2D:
-		current.radius *= scale
-		return
-	if current is RectangleShape2D:
-		current.size *= scale
-		return
-	if current is SegmentShape2D:
-		current.a *= size
-		current.b *= size
-		return
-
-	var transform = Transform2D(0, Vector2.ONE * scale, 0, Vector2.ZERO)
-	if current is ConvexPolygonShape2D:
-		current.points *= transform
-		return
-	if current is ConcavePolygonShape2D:
-		current.segments *= transform
-		return
-	
-	printerr("unexpected shape found: (%s)" % current)
-
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):
@@ -75,37 +41,6 @@ var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
 		queue_regenerate()
-
-func rotate_shape(radian : float) -> void:
-	var current = shape
-	_queue_status = _BLOCK_QUEUE
-	offset_rotation += radian
-	_queue_status = _NOT_QUEUED
-	
-	if current == null:
-		regenerate()
-		return
-
-	if current is CircleShape2D:
-		return
-	
-	if current is RectangleShape2D:
-		regenerate()
-		return
-
-	var transform := Transform2D(radian, Vector2.ONE, 0, Vector2.ZERO)
-	if current is SegmentShape2D:
-		current.a *= transform
-		current.b *= transform
-		return
-	if current is ConvexPolygonShape2D:
-		current.points *= transform
-		return
-	if current is ConcavePolygonShape2D:
-		current.segments *= transform
-		return
-	
-	printerr("unexpected shape found: (%s)" % current)
 
 ## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 ## This method modifies the existing [member CollisionShape2D.shape], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -107,6 +107,13 @@ func rotate_shape(radian : float) -> void:
 	
 	printerr("unexpected shape found: (%s)" % current)
 
+## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## This method modifies the existing [member CollisionShape2D.shape], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
+## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
+## [br][br][param scale_width] toggles scaling [member width].
+## [param scale_corner_size] toggles scaling [member corner_size].
+## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
+## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -44,12 +44,12 @@ var offset_rotation : float = 0:
 
 ## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 ## This method modifies the existing [member CollisionShape2D.shape], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
-## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
+## This only happens if the transformed shape is congruent to the original, otherwise it is simply regenerated. Certain cases will also cause it to regenerate.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
-## If these values are false, their respective properties are not altered and the shape is corrected.
+## If these values are [code]false[/code], their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
-## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
+## If this occurs in the original or transformed shape and [param scale_corner_size] is [code]false[/code], the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -135,7 +135,8 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 		previous_outer_point = points[size / 2 - 2]
 		previous_inner_point = points[size / 2 + 1]
 
-	for i in size / points_per_corner / (2 if is_ringed_shape else 1):
+	var iterations_count := size / points_per_corner / (2 if is_ringed_shape else 1)
+	for i in iterations_count:
 		var index := i * points_per_corner
 		var outer_point := Vector2.ZERO
 		var inner_point := Vector2.ZERO
@@ -160,11 +161,21 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 			for i2 in points_per_corner:
 				points[index + i2] = points[index + i2].lerp(outer_point, delta)
 
+
 		if not is_ringed_shape:
 			continue
 
 		if scale_corner_size:
 			if scale_width:
+				continue
+			
+			if not complete_shape_arc and (i == 0 or i + 1 == iterations_count):
+				var offset = i / (iterations_count - 1) * (points_per_corner - 1)
+				outer_point = points[index + points_per_corner - 1 - offset]
+				inner_point = points[-index - points_per_corner + offset]
+				var slope := (outer_point - inner_point) * delta
+				for i2 in points_per_corner:
+					points[-index - i2 - 1] = points[-index - i2 - 1] + slope
 				continue
 			
 			for i2 in points_per_corner:

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -188,7 +188,7 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, delta)
 
 	if complete_shape_arc:
-		var offsetting_slope := (points[size / 2 - 1] - previous_outer_point) / 4194304 # 2^22
+		var offsetting_slope := (points[size / 2 - 2] - points[0]) / 4194304 # 2^22
 		points[size / 2 - 1] = points[0] + offsetting_slope
 		points[size / 2] = points[-1] + offsetting_slope
 

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -108,6 +108,13 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 
+## Transforms [param points], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## [br][br][param is_ringed_shape] indicates the shape forms a ringed shape.
+## [param points_per_corner] indicates the shape has rounded corners and how many points form each rounded corner.
+## [param scale_width] toggles scaling the width formed by the ring.
+## [param scale_corner_size] toggles scaling the size of the rounded corners.
+## [br][br][b]Note[/b]: The method does not check if the transformation would result in a different shape then its properties would suggest,
+## such as shrinking a ring shape to the point it is no longer ringed or having a corner size larger than the a side length.
 static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, is_ringed_shape := false, points_per_corner := 1, scale_width := false, scale_corner_size := false) -> void:
 	assert(points.size() >= 3, "param 'points' does not represent a proper shape.")
 	assert(scaler > 0, "param 'scaler' should be positive.")

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -126,7 +126,9 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 	for i in size:
 		points[i] *= transform
 
-	if not has_rounded_corners and not is_ringed_shape or is_equal_approx(scaler, 1):
+	scale_corner_size = scale_corner_size or not has_rounded_corners
+	scale_width = scale_width or not is_ringed_shape
+	if scale_corner_size and scale_width or is_equal_approx(scaler, 1):
 		return
 
 	var delta := 1 - (1 / scaler)
@@ -164,7 +166,6 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 		if not scale_corner_size:
 			for i2 in points_per_corner:
 				points[index + i2] = points[index + i2].lerp(outer_point, delta)
-
 
 		if not is_ringed_shape:
 			continue

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -114,9 +114,6 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")
 	var size := points.size()
 	var has_rounded_corners := points_per_corner != 1
-	var width := 0.0
-	if is_ringed_shape:
-		width = (points[-1] - points[0]).length()
 	
 	var transform := Transform2D(-rotation, Vector2.ONE * scaler, 0, Vector2.ZERO)
 	for i in size:

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -108,7 +108,7 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 
-static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, points_per_corner := 1, is_ringed_shape := false, scale_width := false, scale_corner_size := false) -> void:
+static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, is_ringed_shape := false, points_per_corner := 1, scale_width := false, scale_corner_size := false) -> void:
 	assert(points.size() >= 3, "param 'points' does not represent a proper shape.")
 	assert(scaler > 0, "param 'scaler' should be positive.")
 	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -115,7 +115,7 @@ static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, en
 ## [param scale_corner_size] toggles scaling the size of the rounded corners.
 ## [br][br][b]Note[/b]: The method does not check if the transformation would result in a different shape then its properties would suggest,
 ## such as shrinking a ring shape to the point it is no longer ringed or having a corner size larger than the a side length.
-static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, is_ringed_shape := false, points_per_corner := 1, scale_width := false, scale_corner_size := false) -> void:
+static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, is_ringed_shape := false, points_per_corner := 1, scale_width := true, scale_corner_size := true) -> void:
 	assert(points.size() >= 3, "param 'points' does not represent a proper shape.")
 	assert(scaler > 0, "param 'scaler' should be positive.")
 	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -108,6 +108,75 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 
+static func apply_transformation(points : PackedVector2Array, rotation : float, scaler : float, points_per_corner := 1, is_ringed_shape := false) -> void:
+	assert(points.size() >= 3, "param 'points' does not represent a proper shape.")
+	assert(scaler > 0, "param 'scaler' should be positive.")
+	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")
+	var size := points.size()
+	var has_rounded_corners := points_per_corner != 1
+	var width := 0.0
+	if is_ringed_shape:
+		width = (points[-1] - points[0]).length()
+	
+	var transform := Transform2D(-rotation, Vector2.ONE * scaler, 0, Vector2.ZERO)
+	for i in size:
+		points[i] *= transform
+
+	if not has_rounded_corners and not is_ringed_shape or is_zero_approx(scaler):
+		return
+
+	var delta := 1 - (1 / scaler)
+	var previous_outer_point := points[-1]
+	var previous_inner_point := points[0]
+	var complete_shape_arc := false
+	if is_ringed_shape and points[-1].is_equal_approx(points[size / 2]):
+		assert(points[0].is_equal_approx(points[size / 2 - 1]), "expected two pairs of points to be on top of each other, forming an identical line used to draw a ringed shape")
+		complete_shape_arc = true
+		previous_outer_point = points[size / 2 - 2]
+		previous_inner_point = points[size / 2 + 1]
+
+	for i in size / points_per_corner / (2 if is_ringed_shape else 1):
+		var index := i * points_per_corner
+		var outer_point := Vector2.ZERO
+		var inner_point := Vector2.ZERO
+		
+		if not has_rounded_corners:
+			outer_point = points[index]
+			inner_point = points[-index - 1]
+			points[-index - 1] = inner_point.lerp(outer_point, delta)
+			continue
+
+		var first_point1 := points[index]
+		var last_point1 := points[index + points_per_corner - 1]
+		var first_slope1 := first_point1 - previous_outer_point
+		var last_slope1 := last_point1 - points[index + points_per_corner - size]
+		var a := _find_intersection(first_point1, first_slope1, last_point1, last_slope1)
+		outer_point = first_point1 + first_slope1 * a
+		for i2 in points_per_corner:
+			points[index + i2] = points[index + i2].lerp(outer_point, delta)
+		
+		previous_outer_point = last_point1
+
+		if not is_ringed_shape:
+			continue
+		
+		for i2 in points_per_corner:
+			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(outer_point, delta)
+			pass
+
+	if complete_shape_arc:
+		var offsetting_slope := (points[size / 2 - 1] - previous_outer_point) / 4194304 # 2^22
+		points[size / 2 - 1] = points[0] + offsetting_slope
+		points[size / 2] = points[-1] + offsetting_slope
+
+# finds the intersection between 2 points and their slopes. The value returned is not the point itself, but a scaler.
+# The point would be obtained by (where a = returned value of function): point1 + a * slope1
+static func _find_intersection(point1 : Vector2, slope1 : Vector2, point2: Vector2, slope2: Vector2) -> float:
+	var numerator := slope2.y * (point2.x - point1.x) - slope2.x * (point2.y - point1.y)
+	var devisor := (slope1.x * slope2.y) - (slope1.y * slope2.x)
+	assert(devisor != 0, "one or both slopes are 0, or are parallel")
+	return numerator / devisor 
+	
 ## sub class that designates how much each method expands the array.
 class SizeIncrease:
 	extends Object

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -119,7 +119,7 @@ static func apply_transformation(points : PackedVector2Array, rotation : float, 
 	for i in size:
 		points[i] *= transform
 
-	if not has_rounded_corners and not is_ringed_shape or is_zero_approx(scaler):
+	if not has_rounded_corners and not is_ringed_shape or is_equal_approx(scaler, 1):
 		return
 
 	var delta := 1 - (1 / scaler)

--- a/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
@@ -143,6 +143,20 @@ public class RegularPolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <inheritdoc cref="SimplePolygon2D.ApplyTransform(float, float)"/>
+    /// <summary>
+    /// Transforms <see cref="Polygon2D.Polygon"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method modifies the existing <see cref="Polygon2D.Polygon"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="Polygon2D.Polygon"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+
     /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.

--- a/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
@@ -143,7 +143,7 @@ public class RegularPolygon2D
         set => Instance.Scale = value;
     }
 
-    /// <inheritdoc cref="SimplePolygon2D.ApplyTransform(float, float)"/>
+    /// <inheritdoc cref="SimplePolygon2D.ApplyTransformation(float, float)"/>
     /// <summary>
     /// Transforms <see cref="Polygon2D.Polygon"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
     /// </summary>
@@ -155,7 +155,7 @@ public class RegularPolygon2D
     /// </remarks>
     /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
     /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
-    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -51,9 +51,14 @@ func apply_transformation(rotation : float, scale : float) -> void:
 	offset_rotation += rotation
 	size *= scale
 	_queue_status = _NOT_QUEUED
-
+	
 	if not uses_polygon_member():
 		queue_redraw()
+		return
+
+	if width > size and width < size / scale or \
+	   width < size and width > size / scale:
+		regenerate_polygon()
 		return
 	
 	var shape := polygon

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -496,23 +496,8 @@ static func resize_points_size(points : PackedVector2Array, scaler : float, poin
 			continue
 		
 		for i2 in points_per_corner:
-			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(points[index + i2], delta)
-
-		var first_point2 := points[-index - 1]
-		var last_point2 := points[-index - points_per_corner]
-		var first_slope2 := first_point2 - previous_inner_point
-		var last_slope2 := last_point2 - points[-index - points_per_corner - 1 + size]
-		var b := _find_intersection(first_point2, first_slope2, last_point2, last_slope2)
-		inner_point = first_point2 + first_slope2 * b
-		# points[-index - 2] = inner_point
-		for i2 in points_per_corner:
-			# points[-index - i2 - 1] = points[index + i2]
-			# points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, 1 / width)
-			# points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, delta) + (outer_point - inner_point) * delta
-			# points[-index - i2 - 1] = points[-index - i2 - 1] + (outer_point - inner_point) * delta
+			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(outer_point, delta)
 			pass
-
-		previous_inner_point = last_point2
 
 	if complete_shape_arc:
 		var offsetting_slope := (points[size / 2 - 1] - previous_outer_point) / 4194304 # 2^22

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -31,6 +31,19 @@ var size : float = 10:
 		size = value
 		_pre_redraw()
 
+func apply_size_scale(scale : float):
+	assert(scale > 0, "param 'scale' should be positive.")
+	if not uses_polygon_member():
+		size *= scale
+		return
+
+	_queue_status = _BLOCK_QUEUE
+	size *= scale
+	_queue_status = _NOT_QUEUED
+	var shape = polygon
+	var transform = Transform2D(0, Vector2.ONE * scale, 0, Vector2.ZERO)
+	polygon = shape * transform
+
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -50,9 +50,9 @@ var offset_rotation : float = 0:
 ## This only happens if the transformed shape is congruent to the original. If it is not or [member Polygon2D.polygon] isn't used, the shape is regenerated.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
-## If these values are false, their respective properties are not altered and the shape is corrected.
+## If these values are [code]false[/code], their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
-## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
+## If this occurs in the original or transformed shape and [param scale_corner_size] is [code]false[/code], the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -41,7 +41,7 @@ func apply_size_scale(scale : float) -> void:
 	size *= scale
 	_queue_status = _NOT_QUEUED
 	var shape = polygon
-	resize_points_size(shape, scale, 0 if is_zero_approx(corner_size) else (corner_smoothness if corner_smoothness != 0 else 32) + 1, 0 < width and width < size)
+	resize_points_size(shape, scale, 1 if is_zero_approx(corner_size) else (corner_smoothness if corner_smoothness != 0 else 32) + 1, 0 < width and width < size)
 	polygon = shape
 
 ## The offset rotation of the shape, in degrees.
@@ -450,6 +450,10 @@ static func resize_points_size(points : PackedVector2Array, scaler : float, poin
 	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")
 	var size := points.size()
 	var has_rounded_corners := points_per_corner != 1
+	var width := 0.0
+	if is_ringed_shape:
+		width = (points[-1] - points[0]).length()
+	
 	for i in size:
 		points[i] *= scaler
 
@@ -491,14 +495,22 @@ static func resize_points_size(points : PackedVector2Array, scaler : float, poin
 		if not is_ringed_shape:
 			continue
 		
+		for i2 in points_per_corner:
+			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(points[index + i2], delta)
+
 		var first_point2 := points[-index - 1]
 		var last_point2 := points[-index - points_per_corner]
 		var first_slope2 := first_point2 - previous_inner_point
 		var last_slope2 := last_point2 - points[-index - points_per_corner - 1 + size]
 		var b := _find_intersection(first_point2, first_slope2, last_point2, last_slope2)
 		inner_point = first_point2 + first_slope2 * b
+		# points[-index - 2] = inner_point
 		for i2 in points_per_corner:
-			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, delta / 2) + (outer_point - inner_point) * delta
+			# points[-index - i2 - 1] = points[index + i2]
+			# points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, 1 / width)
+			# points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, delta) + (outer_point - inner_point) * delta
+			# points[-index - i2 - 1] = points[-index - i2 - 1] + (outer_point - inner_point) * delta
+			pass
 
 		previous_inner_point = last_point2
 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -41,8 +41,8 @@ func apply_size_scale(scale : float) -> void:
 	size *= scale
 	_queue_status = _NOT_QUEUED
 	var shape = polygon
-	var transform = Transform2D(0, Vector2.ONE * scale, 0, Vector2.ZERO)
-	polygon = shape * transform
+	resize_points_size(shape, scale, 0 if is_zero_approx(corner_size) else (corner_smoothness if corner_smoothness != 0 else 32) + 1, 0 < width and width < size)
+	polygon = shape
 
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
@@ -443,6 +443,69 @@ static func add_hole_to_points(points : PackedVector2Array, hole_scaler : float,
 		var slope := (points[original_size - 2] - points[original_size - 1]) / 4194304 # 2^22
 		points[original_size - 1] += slope
 		points[original_size] += slope
+
+static func resize_points_size(points : PackedVector2Array, scaler : float, points_per_corner := 0, is_ringed_shape := false) -> void:
+	assert(points.size() >= 3, "param 'points' does not represent a proper shape.")
+	assert(scaler > 0, "param 'scaler' should be positive.")
+	assert(points_per_corner > 0, "param 'points_per_corner' should be positive.")
+	var size := points.size()
+	var has_rounded_corners := points_per_corner != 1
+	for i in size:
+		points[i] *= scaler
+
+	if not has_rounded_corners and not is_ringed_shape:
+		return
+
+	var delta := 1 - (1 / scaler)
+	var previous_outer_point := points[-1]
+	var previous_inner_point := points[0]
+	var complete_shape_arc := false
+	if is_ringed_shape and points[-1].is_equal_approx(points[size / 2]):
+		assert(points[0].is_equal_approx(points[size / 2 - 1]), "expected two pairs of points to be on top of each other, forming an identical line used to draw a ringed shape")
+		complete_shape_arc = true
+		previous_outer_point = points[size / 2 - 2]
+		previous_inner_point = points[size / 2 + 1]
+
+	for i in size / points_per_corner / (2 if is_ringed_shape else 1):
+		var index := i * points_per_corner
+		var outer_point := Vector2.ZERO
+		var inner_point := Vector2.ZERO
+		
+		if not has_rounded_corners:
+			outer_point = points[index]
+			inner_point = points[-index - 1]
+			points[-index - 1] = inner_point.lerp(outer_point, delta)
+			continue
+
+		var first_point1 := points[index]
+		var last_point1 := points[index + points_per_corner - 1]
+		var first_slope1 := first_point1 - previous_outer_point
+		var last_slope1 := last_point1 - points[index + points_per_corner - size]
+		var a := _find_intersection(first_point1, first_slope1, last_point1, last_slope1)
+		outer_point = first_point1 + first_slope1 * a
+		for i2 in points_per_corner:
+			points[index + i2] = points[index + i2].lerp(outer_point, delta)
+		
+		previous_outer_point = last_point1
+
+		if not is_ringed_shape:
+			continue
+		
+		var first_point2 := points[-index - 1]
+		var last_point2 := points[-index - points_per_corner]
+		var first_slope2 := first_point2 - previous_inner_point
+		var last_slope2 := last_point2 - points[-index - points_per_corner - 1 + size]
+		var b := _find_intersection(first_point2, first_slope2, last_point2, last_slope2)
+		inner_point = first_point2 + first_slope2 * b
+		for i2 in points_per_corner:
+			points[-index - i2 - 1] = points[-index - i2 - 1].lerp(inner_point, delta / 2) + (outer_point - inner_point) * delta
+
+		previous_inner_point = last_point2
+
+	if complete_shape_arc:
+		var offsetting_slope := (points[size / 2 - 1] - previous_outer_point) / 4194304 # 2^22
+		points[size / 2 - 1] = points[0] + offsetting_slope
+		points[size / 2] = points[-1] + offsetting_slope
 
 # these functions are for c# interop, as changes to an argument are not transferred.
 static func _add_rounded_corners_result(points : PackedVector2Array, corner_size : float, corner_smoothness : int) -> PackedVector2Array:

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -50,9 +50,10 @@ var offset_rotation : float = 0:
 ## This only happens if the transformed shape is congruent to the original. If it is not or [member Polygon2D.polygon] isn't used, the shape is regenerated.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
+## If these values are false, their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
 ## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
-func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
+func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE
 	offset_rotation += rotation

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -73,7 +73,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := false,
 	points_per_corner += 1
 	
 	var shape := polygon
-	RegularGeometry2D.apply_transformation(shape, rotation, scale, points_per_corner, 0 < width and width < size, scale_width, scale_corner_size)
+	RegularGeometry2D.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
 	polygon = shape
 
 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -62,8 +62,9 @@ func apply_transformation(rotation : float, scale : float, scale_width := false,
 		queue_redraw()
 		return
 
-	if not scale_width and width >= size and width < size / scale \
-		or width < size and width >= size / scale:
+	if not scale_width and \
+		(width >= size and width < size / scale
+		or width < size and width >= size / scale):
 		regenerate_polygon()
 		return
 	

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -45,24 +45,35 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
-func apply_transformation(rotation : float, scale : float) -> void:
+func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE
 	offset_rotation += rotation
 	size *= scale
+	if scale_width:
+		width *= scale
+
+	if scale_corner_size:
+		corner_size *= scale
+
 	_queue_status = _NOT_QUEUED
 	
 	if not uses_polygon_member():
 		queue_redraw()
 		return
 
-	if width > size and width < size / scale or \
-	   width < size and width > size / scale:
+	if not scale_width and width >= size and width < size / scale \
+		or width < size and width >= size / scale:
 		regenerate_polygon()
 		return
 	
+	var points_per_corner := 0
+	if corner_size > 0:
+		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / vertices_count
+	points_per_corner += 1
+	
 	var shape := polygon
-	RegularGeometry2D.apply_transformation(shape, rotation, scale, 1 if is_zero_approx(corner_size) else (corner_smoothness if corner_smoothness != 0 else 32) + 1, 0 < width and width < size)
+	RegularGeometry2D.apply_transformation(shape, rotation, scale, points_per_corner, 0 < width and width < size, scale_width, scale_corner_size)
 	polygon = shape
 
 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -45,6 +45,13 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
+## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size] and [member offset_rotation].
+## This only happens if the transformed shape is congruent to the original. If it is not or [member Polygon2D.polygon] isn't used, the shape is regenerated.
+## [br][br][param scale_width] toggles scaling [member width].
+## [param scale_corner_size] toggles scaling [member corner_size].
+## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
+## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -45,6 +45,18 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
+func rotate_shape(radian : float) -> void:
+	if not uses_polygon_member():
+		offset_rotation += radian
+		return
+	
+	_queue_status = _BLOCK_QUEUE
+	offset_rotation += radian
+	_queue_status = _NOT_QUEUED
+	var shape = polygon;
+	var matrix = Transform2D(radian, Vector2.ONE, 0, Vector2.ZERO)
+	polygon = matrix * shape
+
 # ? not sure if this is a good name for it and many of the properties under it, they may need changing.
 @export_group("complex")
 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -31,7 +31,7 @@ var size : float = 10:
 		size = value
 		_pre_redraw()
 
-func apply_size_scale(scale : float):
+func apply_size_scale(scale : float) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	if not uses_polygon_member():
 		size *= scale

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -89,8 +89,8 @@ public partial class SimplePolygon2D
     /// <remarks>Unlike other methods, this simply affects <see cref="OffsetRotation"/> and <see cref="Size"/>, regenerating the shape </remarks>
     /// <param name="rotation">The amount to rotate the shape in radians.</param>
     /// <param name="scale">The factor to scale the shape.</param>
-    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
-    public void ApplyTransform(float rotation, float scale) => Instance.Call(MethodName.ApplyTransform, rotation, scale);
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransformation(float rotation, float scale) => Instance.Call(MethodName.ApplyTransformation, rotation, scale);
 
     /// <summary>Creates and wraps a <see cref="SimplePolygon2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -83,6 +83,15 @@ public partial class SimplePolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <summary>
+    /// Transforms <see cref="SimplePolygon2D"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>Unlike other methods, this simply affects <see cref="OffsetRotation"/> and <see cref="Size"/>, regenerating the shape </remarks>
+    /// <param name="rotation">The amount to rotate the shape in radians.</param>
+    /// <param name="scale">The factor to scale the shape.</param>
+    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransform(float rotation, float scale) => Instance.Call(MethodName.ApplyTransform, rotation, scale);
+
     /// <summary>Creates and wraps a <see cref="SimplePolygon2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>
     /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -39,6 +39,7 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		queue_redraw()
 
+## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 func apply_transform(rotation : float, scale : float) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	offset_rotation += rotation

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -40,7 +40,7 @@ var offset_rotation : float = 0:
 		queue_redraw()
 
 ## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
-func apply_transform(rotation : float, scale : float) -> void:
+func apply_transformation(rotation : float, scale : float) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	offset_rotation += rotation
 	size *= scale

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -25,10 +25,6 @@ var size : float = 10:
 		assert(value > 0, "property 'size' must be greater than 0.");
 		queue_redraw()
 
-func apply_size_scale(scale : float) -> void:
-	assert(scale > 0, "param 'scale' should be positive.")
-	size *= scale
-	
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):
@@ -43,8 +39,10 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		queue_redraw()
 
-func rotate_shape(radian : float) -> void:
-	offset_rotation += radian
+func apply_transform(rotation : float, scale : float) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	offset_rotation += rotation
+	size *= scale
 
 ## The color of the shape.
 @export

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -25,6 +25,10 @@ var size : float = 10:
 		assert(value > 0, "property 'size' must be greater than 0.");
 		queue_redraw()
 
+func apply_size_scale(scale : float) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	size *= scale
+	
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):
@@ -38,6 +42,9 @@ var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
 		queue_redraw()
+
+func rotate_shape(radian : float) -> void:
+	offset_rotation += radian
 
 ## The color of the shape.
 @export

--- a/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
+++ b/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
@@ -129,7 +129,7 @@ public class StarPolygon2D
         set => Instance.Scale = value;
     }
 
-    /// <inheritdoc cref="RegularPolygon2D.ApplyTransform(float, float, bool, bool)"/>
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransformation(float, float, bool, bool)"/>
     /// <remarks>
     /// This method modifies the existing <see cref="Polygon2D.Polygon"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
     /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="Polygon2D.Polygon"/> isn't used, the shape is regenerated.
@@ -138,7 +138,7 @@ public class StarPolygon2D
     /// </remarks>
     /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
     /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
-    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>
     /// Sets <see cref="innerSize"/> such that the angle formed by each point is equivalent to <paramref name="angle"/>, in radians.

--- a/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
+++ b/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
@@ -129,6 +129,17 @@ public class StarPolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransform(float, float, bool, bool)"/>
+    /// <remarks>
+    /// This method modifies the existing <see cref="Polygon2D.Polygon"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="Polygon2D.Polygon"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransform(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransform, rotation, scale, scale_width, scale_corner_size);
+
     /// <summary>
     /// Sets <see cref="innerSize"/> such that the angle formed by each point is equivalent to <paramref name="angle"/>, in radians.
     /// </summary>

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -54,6 +54,13 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
+## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## This method modifies the existing [member CollisionShape2D.shape], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
+## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
+## [br][br][param scale_width] toggles scaling [member width].
+## [param scale_corner_size] toggles scaling [member corner_size].
+## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
+## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -59,9 +59,10 @@ var offset_rotation : float = 0:
 ## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
+## If these values are false, their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
 ## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
-func apply_transformation(rotation : float, scale : float, scale_width := false, scale_corner_size := false) -> void:
+func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE
 	offset_rotation += rotation

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -54,14 +54,14 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
-## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
-## This method modifies the existing [member CollisionShape2D.shape], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
-## This only happens if the transformed shape is congruent to the original. If it is not or [member CollisionShape2D.shape] isn't used, the shape is regenerated.
+## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
+## This only happens if the transformed shape is congruent to the original. If it is not or [member Polygon2D.polygon] isn't used, the shape is regenerated.
 ## [br][br][param scale_width] toggles scaling [member width].
 ## [param scale_corner_size] toggles scaling [member corner_size].
-## If these values are false, their respective properties are not altered and the shape is corrected.
+## If these values are [code]false[/code], their respective properties are not altered and the shape is corrected.
 ## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
-## If this occurs in the original or transformed shape, the shape will not be accurate to this node's properties.
+## If this occurs in the original or transformed shape and [param scale_corner_size] is [code]false[/code], the shape will not be accurate to this node's properties.
 func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
 	assert(scale > 0, "param 'scale' should be positive.")
 	_queue_status = _BLOCK_QUEUE

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -40,6 +40,22 @@ var inner_size : float = 5.0:
 		inner_size = value
 		_pre_redraw()
 
+func apply_size_scale(scale : float) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+
+	_queue_status = _BLOCK_QUEUE
+	size *= scale
+	inner_size *= scale
+	
+	if not uses_polygon_member():
+		regenerate_polygon()
+		return
+
+	_queue_status = _NOT_QUEUED
+	var shape = polygon
+	var transform = Transform2D(0, Vector2.ONE * scale, 0, Vector2.ZERO)
+	polygon = shape * transform
+
 ## The offset rotation of the star, in degrees.
 var offset_rotation_degrees : float = 0:
 	set(value):
@@ -53,6 +69,18 @@ var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
 		_pre_redraw()
+
+func rotate_shape(radian : float) -> void:
+	_queue_status = _BLOCK_QUEUE
+	offset_rotation += radian
+	_queue_status = _NOT_QUEUED
+	if not uses_polygon_member():
+		regenerate_polygon()
+		return
+
+	var shape = polygon;
+	var matrix = Transform2D(radian, Vector2.ONE, 0, Vector2.ZERO)
+	polygon = matrix * shape
 
 @export_group("complex")
 

--- a/tests/c#_interop/RegularCollisionPolygon2DTests.cs
+++ b/tests/c#_interop/RegularCollisionPolygon2DTests.cs
@@ -142,7 +142,7 @@ public class RegularCollisionPolygon2DTests : TestClass
         expected.Regenerate();
         sample.Regenerate();
 
-        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 
         sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
         sample.Size.ShouldBe(expected.Size);

--- a/tests/c#_interop/RegularCollisionPolygon2DTests.cs
+++ b/tests/c#_interop/RegularCollisionPolygon2DTests.cs
@@ -129,4 +129,22 @@ public class RegularCollisionPolygon2DTests : TestClass
 
         result.Length.ShouldBe(16);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularCollisionPolygon2D expected = new(4, 10, 0, 0, Mathf.Tau, 1, 1);
+        RegularCollisionPolygon2D sample = new(4, 10, 0, 0, Mathf.Tau, 1, 1);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.Regenerate();
+        sample.Regenerate();
+
+        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -153,7 +153,7 @@ public class RegularPolygon2DTests : TestClass
         expected.RegeneratePolygon();
         sample.RegeneratePolygon();
 
-        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 
         sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
         sample.Size.ShouldBe(expected.Size);

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -140,4 +140,22 @@ public class RegularPolygon2DTests : TestClass
 
         result.ShouldNotBeEmpty();
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/SimplePolygon2DTests.cs
+++ b/tests/c#_interop/SimplePolygon2DTests.cs
@@ -70,4 +70,22 @@ public class SimplePolygon2DTests : TestClass
 
         array.Length.ShouldBe(4);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/SimplePolygon2DTests.cs
+++ b/tests/c#_interop/SimplePolygon2DTests.cs
@@ -83,7 +83,7 @@ public class SimplePolygon2DTests : TestClass
         expected.RegeneratePolygon();
         sample.RegeneratePolygon();
 
-        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 
         sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
         sample.Size.ShouldBe(expected.Size);

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -144,7 +144,7 @@ public class StarPolygon2DTests : TestClass
         expected.RegeneratePolygon();
         sample.RegeneratePolygon();
 
-        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 
         sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
         sample.Size.ShouldBe(expected.Size);

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -131,4 +131,22 @@ public class StarPolygon2DTests : TestClass
 
         array.Length.ShouldBe(8);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransform(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -1,5 +1,20 @@
 extends GutTest
 
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
+		return
+	
+	var has_failed := false
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
+			has_failed = true
+
+	if not has_failed:
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+
+
 var class_script := preload("res://addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])
 
@@ -161,15 +176,16 @@ func test_add_hole_to_points__do_close_shape__array_size_doubles_plus_2():
 
 	assert_eq(new_size, 2 * previous_size + 2, "Size of modified array, 2 + 2 * the original size")
 
-var params_rotate_shape := [
-	[4, 10, 10, TAU, 0, 0],
-	[20, 10, 10, TAU, 0, 0],
+var params_transform_shape := [
+	[4, 10, 100, TAU, 0, 0],
+	[20, 10, 100, TAU, 0, 0],
 	[4, 100, 10, TAU, 0, 0],
-	[4, 10, 5, -PI, 3, 4],
-	[8, 30, 15, 2, 1, 2],
+	[4, 10, 5, -PI, 1.2, 3],
+	[8, 30, 15, 2.269, 1, 2],
 ]
-func test_rotate_shape__various_shape_types__almost_expected_result(p=use_parameters(params_rotate_shape)):
-	const sample_rotation_amount = PI / 8;
+func test_apply_transform__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
+	const sample_rotation_amount = 2;
+	const sample_scale_amount := PI
 	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
 	var shape : RegularPolygon2D = partial_double(class_script).new()
 	shape.vertices_count = p[0]
@@ -178,6 +194,7 @@ func test_rotate_shape__various_shape_types__almost_expected_result(p=use_parame
 	shape.drawn_arc = p[3]
 	shape.corner_size = p[4]
 	shape.corner_smoothness = p[5]
+	shape.regenerate_polygon()
 	var expected := RegularPolygon2D.new()
 	expected.vertices_count = p[0]
 	expected.size = p[1]
@@ -185,38 +202,23 @@ func test_rotate_shape__various_shape_types__almost_expected_result(p=use_parame
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	autoqfree(expected)
-	# sub-setup
-	shape.regenerate_polygon()
-	expected.offset_rotation +=  sample_rotation_amount
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
 	expected.regenerate_polygon()
+	autoqfree(expected)
 
-	shape.rotate_shape(sample_rotation_amount)
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount)
 
-	assert_almost_eq(shape.polygon[0], expected.polygon[0], Vector2.ONE * 0.001)
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
-func test_apply_size_scale__various_shape_types__almost_expected_result(p=use_parameters(params_rotate_shape)):
+func test_apply_transform__size_change_creates_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 2
-	var shape : RegularPolygon2D = partial_double(class_script).new()
-	shape.vertices_count = p[0]
-	shape.size = p[1]
-	shape.width = p[2]
-	shape.drawn_arc = p[3]
-	shape.corner_size = p[4]
-	shape.corner_smoothness = p[5]
-	var expected := RegularPolygon2D.new()
-	expected.vertices_count = p[0]
-	expected.size = p[1]
-	expected.width = p[2]
-	expected.drawn_arc = p[3]
-	expected.corner_size = p[4]
-	expected.corner_smoothness = p[5]
-	autoqfree(expected)
-	# sub-setup
+	var expected_shape := PackedVector2Array([14.1421, 14.1421, -14.1421, 14.1421, -14.1421, -14.1421, 14.1421, -14.1421, 14.1421, 14.1421, 3.53553, 3.53553, 3.53553, -3.53553, -3.53553, -3.53553, -3.53553, 3.53553, 3.53553, 3.53553])
+	var shape := RegularPolygon2D.new()
+	shape.vertices_count = 4
+	shape.width = 15
 	shape.regenerate_polygon()
-	expected.size *=  sample_scale_amount
-	expected.regenerate_polygon()
 
-	shape.apply_size_scale(sample_scale_amount)
+	shape.apply_transformation(0, sample_scale_amount)
 
-	assert_almost_eq(shape.polygon[0], expected.polygon[0], Vector2.ONE * 0.001)
+	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -210,7 +210,7 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	expected.size *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(sample_rotation_amount, sample_scale_amount)
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 	assert_not_called(shape, "regenerate_polygon")
@@ -224,7 +224,7 @@ func test_apply_transformation__size_change_creates_ring__shape_regenerated() ->
 	shape.regenerate_polygon()
 	autoqfree(shape)
 
-	shape.apply_transformation(0, sample_scale_amount)
+	shape.apply_transformation(0, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
 
@@ -238,7 +238,7 @@ func test_apply_transformation__size_change_removes_ring__shape_regenerated() ->
 	shape.regenerate_polygon()
 	autoqfree(shape)
 
-	shape.apply_transformation(0, sample_scale_amount)
+	shape.apply_transformation(0, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
 
@@ -269,7 +269,7 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	expected.width *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true)
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 	assert_not_called(shape, "regenerate_polygon")

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -180,7 +180,7 @@ var params_transform_shape := [
 	[4, 10, 100, TAU, 0, 0],
 	[20, 10, 100, TAU, 0, 0],
 	[4, 100, 10, TAU, 0, 0],
-	[4, 10, 5, -PI, 1.2, 3],
+	[4, 10, 5, -PI, 0.5, 3],
 	[8, 30, 15, 2.269, 1, 2],
 ]
 func test_apply_transformation__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
@@ -188,28 +188,32 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	const sample_scale_amount := PI
 	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
 	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
 	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.width = p[2]
 	shape.drawn_arc = p[3]
 	shape.corner_size = p[4]
 	shape.corner_smoothness = p[5]
-	shape.regenerate_polygon()
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
 	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
 	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.regenerate_polygon()
-	autoqfree(expected)
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
 
 func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 2
@@ -237,3 +241,100 @@ func test_apply_transformation__size_change_removes_ring__shape_regenerated() ->
 	shape.apply_transformation(0, sample_scale_amount)
 
 	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
+
+func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -183,7 +183,7 @@ var params_transform_shape := [
 	[4, 10, 5, -PI, 1.2, 3],
 	[8, 30, 15, 2.269, 1, 2],
 ]
-func test_apply_transform__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
+func test_apply_transformation__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
 	const sample_rotation_amount = 2;
 	const sample_scale_amount := PI
 	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
@@ -211,13 +211,28 @@ func test_apply_transform__various_shape_types__almost_expected_result(p=use_par
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
-func test_apply_transform__size_change_creates_ring__shape_regenerated() -> void:
+func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 2
-	var expected_shape := PackedVector2Array([14.1421, 14.1421, -14.1421, 14.1421, -14.1421, -14.1421, 14.1421, -14.1421, 14.1421, 14.1421, 3.53553, 3.53553, 3.53553, -3.53553, -3.53553, -3.53553, -3.53553, 3.53553, 3.53553, 3.53553])
+	var expected_shape := PackedVector2Array([Vector2(14.1421, 14.1421), Vector2(-14.1421, 14.1421), Vector2(-14.1421, -14.1421), Vector2(14.1421, -14.1421), Vector2(14.1421, 14.1421), Vector2(3.53553, 3.53553), Vector2(3.53553, -3.53553), Vector2(-3.53553, -3.53553), Vector2(-3.53553, 3.53553), Vector2(3.53553, 3.53553)])
 	var shape := RegularPolygon2D.new()
 	shape.vertices_count = 4
 	shape.width = 15
 	shape.regenerate_polygon()
+	autoqfree(shape)
+
+	shape.apply_transformation(0, sample_scale_amount)
+
+	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
+
+func test_apply_transformation__size_change_removes_ring__shape_regenerated() -> void:
+	const sample_scale_amount := 0.5
+	var expected_shape := PackedVector2Array([Vector2(7.07107, 7.07107), Vector2(-7.07107, 7.07107), Vector2(-7.07107, -7.07107), Vector2(7.07107, -7.07107)])
+	var shape := RegularPolygon2D.new()
+	shape.vertices_count = 4
+	shape.size = 20
+	shape.width = 15
+	shape.regenerate_polygon()
+	autoqfree(shape)
 
 	shape.apply_transformation(0, sample_scale_amount)
 

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -161,4 +161,62 @@ func test_add_hole_to_points__do_close_shape__array_size_doubles_plus_2():
 
 	assert_eq(new_size, 2 * previous_size + 2, "Size of modified array, 2 + 2 * the original size")
 
+var params_rotate_shape := [
+	[4, 10, 10, TAU, 0, 0],
+	[20, 10, 10, TAU, 0, 0],
+	[4, 100, 10, TAU, 0, 0],
+	[4, 10, 5, -PI, 3, 4],
+	[8, 30, 15, 2, 1, 2],
+]
+func test_rotate_shape__various_shape_types__almost_expected_result(p=use_parameters(params_rotate_shape)):
+	const sample_rotation_amount = PI / 8;
+	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	var expected := RegularPolygon2D.new()
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	autoqfree(expected)
+	# sub-setup
+	shape.regenerate_polygon()
+	expected.offset_rotation +=  sample_rotation_amount
+	expected.regenerate_polygon()
 
+	shape.rotate_shape(sample_rotation_amount)
+
+	assert_almost_eq(shape.polygon[0], expected.polygon[0], Vector2.ONE * 0.001)
+
+func test_apply_size_scale__various_shape_types__almost_expected_result(p=use_parameters(params_rotate_shape)):
+	const sample_scale_amount := 2
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	var expected := RegularPolygon2D.new()
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	autoqfree(expected)
+	# sub-setup
+	shape.regenerate_polygon()
+	expected.size *=  sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_size_scale(sample_scale_amount)
+
+	assert_almost_eq(shape.polygon[0], expected.polygon[0], Vector2.ONE * 0.001)

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -152,7 +152,7 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	expected.inner_size *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(sample_rotation_amount, sample_scale_amount)
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 	assert_not_called(shape, "regenerate_polygon")
@@ -174,7 +174,7 @@ func test_apply_transformation__size_change_creates_ring__shape_regenerated() ->
 	expected.inner_size *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(0, sample_scale_amount)
+	shape.apply_transformation(0, sample_scale_amount, false, false)
 
 	assert_called(shape, "regenerate_polygon")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
@@ -196,7 +196,7 @@ func test_apply_transformation__size_change_removes_ring__shape_regenerated() ->
 	expected.inner_size *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(0, sample_scale_amount)
+	shape.apply_transformation(0, sample_scale_amount, false, false)
 
 	assert_called(shape, "regenerate_polygon")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
@@ -231,7 +231,7 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	expected.width *= sample_scale_amount
 	expected.regenerate_polygon()
 
-	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true)
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 	assert_not_called(shape, "regenerate_polygon")

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -1,5 +1,19 @@
 extends GutTest
 
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
+		return
+	
+	var has_failed := false
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
+			has_failed = true
+
+	if not has_failed:
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+
 var class_script := preload("res://addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])
 
@@ -100,3 +114,195 @@ func test_get_star_vertices__add_central_point_false__expected_size_and_not_ZERO
 
 	assert_almost_ne(star[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last point in the returned array.")
 	assert_eq(star.size(), 9, "Size of the returned array")
+
+var params_transform_shape := [
+	[4, 10, 100, TAU, 0, 0],
+	[20, 10, 100, TAU, 0, 0],
+	[4, 100, 10, TAU, 0, 0],
+	[4, 10, 5, -PI, 0.5, 3],
+	[8, 30, 15, 2.269, 1, 2],
+]
+func test_apply_transformation__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
+	const sample_rotation_amount = 2;
+	const sample_scale_amount := PI
+	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = p[0]
+	shape.size = p[1]
+	shape.inner_size = p[1] / 2.0
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	var expected := StarPolygon2D.new()
+	autoqfree(expected)
+	expected.point_count = p[0]
+	expected.size = p[1]
+	expected.inner_size = p[1] / 2.0
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
+	const sample_scale_amount := 3
+	var expected := StarPolygon2D.new()
+	expected.point_count = 4
+	expected.width = 15
+	expected.regenerate_polygon()
+	autoqfree(expected)
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = 4
+	shape.width = 15
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	shape.polygon = expected.polygon
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(0, sample_scale_amount)
+
+	assert_called(shape, "regenerate_polygon")
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+
+func test_apply_transformation__size_change_removes_ring__shape_regenerated() -> void:
+	const sample_scale_amount := 0.2
+	var expected := StarPolygon2D.new()
+	expected.point_count = 4
+	expected.width = 5
+	expected.regenerate_polygon()
+	autoqfree(expected)
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = 4
+	shape.width = 5
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	shape.polygon = expected.polygon
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(0, sample_scale_amount)
+
+	assert_called(shape, "regenerate_polygon")
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+
+func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = p[0]
+	shape.size = p[1]
+	shape.inner_size = p[1] / 2.0
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	var expected := StarPolygon2D.new()
+	autoqfree(expected)
+	expected.point_count = p[0]
+	expected.size = p[1]
+	expected.inner_size = p[1] / 2.0
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = p[0]
+	shape.size = p[1]
+	shape.inner_size = p[1] / 2.0
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	var expected := StarPolygon2D.new()
+	autoqfree(expected)
+	expected.point_count = p[0]
+	expected.size = p[1]
+	expected.inner_size = p[1] / 2.0
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
+	shape.point_count = p[0]
+	shape.size = p[1]
+	shape.inner_size = p[1] / 2.0
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = StarPolygon2D._NOT_QUEUED
+	var expected := StarPolygon2D.new()
+	autoqfree(expected)
+	expected.point_count = p[0]
+	expected.size = p[1]
+	expected.inner_size = p[1] / 2.0
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.inner_size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")


### PR DESCRIPTION
Where possible, `apply_transformation`, instead of regenerating the entire shape again, modifies the points in the shape. It may still regenerate the shape in certain cases where it is impossible to simply move around the shapes to get the desired effect. It allows options for scaling `width` and `corner_size` or not (true by default).

It is generally faster than regenerating the entire shape.

There are certain caveats with its use. 
- The method does not account for corner_size being limited due to smaller-than-expected side lengths. This causes errors in the transformation making it not accurate when this occurs in the original or transformed shape.
- Certain cases for `RegularCollisionPolygon2D` simply regenerate the shape when it should be possible to modify it. They remain because they are edge cases, I'm lazy, and because I don't think changing collision shapes has too much of a use anyways.