### PR TITLE
Improve Unit Tests

### DIFF
--- a/tests/unit_tests/gut_collection_test.gd
+++ b/tests/unit_tests/gut_collection_test.gd
@@ -1,0 +1,22 @@
+extends GutTest
+class_name GutCollectionTest
+
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
+		return
+	
+	var failed_indexes := PackedInt32Array()
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			failed_indexes.append(i)
+
+	if failed_indexes.is_empty():
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+		return
+	
+	var message := "%s elements do not match at indices: %s" % [failed_indexes.size(), failed_indexes]
+	for i in failed_indexes:
+		message += "\n[%s]: %s vs %s" % [i, c1[i], c2[i]]
+	
+	_fail(message)

--- a/tests/unit_tests/gut_collection_test.gd
+++ b/tests/unit_tests/gut_collection_test.gd
@@ -20,3 +20,13 @@ func assert_almost_eq_deep(c1, c2, error_interval):
 		message += "\n[%s]: %s vs %s" % [i, c1[i], c2[i]]
 	
 	_fail(message)
+
+func to_vector2s(nums : Array) -> PackedVector2Array:
+	assert(nums.size() % 2 == 0)
+	var points := PackedVector2Array()
+	@warning_ignore("integer_division") 
+	points.resize(nums.size() / 2)
+	for i in points.size():
+		points[i] = Vector2(nums[i * 2], nums[i * 2 + 1])
+	
+	return points

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -1,18 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s | %s)" % [c1, c2])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+extends GutCollectionTest
 
 var various_shapes_with_corner_smoothness := [
 	[1, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -123,7 +123,7 @@ func test_regenerate__vertices_count_2__shape_segment_shape():
 
 func test_regenerate__line_with_width_offset_rotation_multiples_of_PI__expected_shape(p = use_parameters([0, PI, -PI, TAU])):
 	var expected_shape := RectangleShape2D.new()
-	expected_shape.size = Vector2(5, 10)
+	expected_shape.size = Vector2(5, 20)
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
 	shape.size = 10
@@ -139,7 +139,7 @@ func test_regenerate__line_with_width_offset_rotation_multiples_of_PI__expected_
 
 func test_regenerate__line_with_width_offset_rotation_multiples_of_PI_plus_PI_over_2__shape_rectangle_wider_than_tall(p = use_parameters([PI / 2, -PI * 3 / 2, PI * 5 / 2])):
 	var expected_shape := RectangleShape2D.new()
-	expected_shape.size = Vector2(10, 5)
+	expected_shape.size = Vector2(20, 5)
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
 	shape.size = 10
@@ -179,8 +179,8 @@ func test_regenerate__line_with_width_uses_drawn_arc__shape_16_point_concave_sha
 		return
 	assert_eq(shape.shape.segments.size(), 16, "Property 'shape.segments' should have 16 points")
 
-func test_regenerate__line_with_width_uses_drawn_arc_and_corner_size__shape_76_point_concave_shape():
-	var expected_shape := PackedVector2Array([Vector2(2.5, -10), Vector2(2.5, -5.40569), Vector2(2.5, -5.40569), Vector2(3.22642, -3.22642), Vector2(3.22642, -3.22642), Vector2(5.40569, -2.5), Vector2(5.40569, -2.5), Vector2(10, -2.5), Vector2(10, -2.5), Vector2(10, 2.5), Vector2(10, 2.5), Vector2(4.59431, 2.5), Vector2(4.59431, 2.5), Vector2(-0.726424, 0.726424), Vector2(-0.726424, 0.726424), Vector2(-2.5, -4.59431), Vector2(-2.5, -4.59431), Vector2(-2.5, -10), Vector2(-2.5, -10), Vector2(2.5, -10)])
+func test_regenerate__line_with_width_uses_drawn_arc_and_corner_size__expected_shape():
+	var expected_shape := to_vector2s([-2.5, 10, -2.5, 5.40569, -2.5, 5.40569, -3.22642, 3.22642, -3.22642, 3.22642, -5.40569, 2.5, -5.40569, 2.5, -10, 2.5, -10, 2.5, -10, -2.5, -10, -2.5, -4.59431, -2.5, -4.59431, -2.5, 0.726424, -0.726424, 0.726424, -0.726424, 2.5, 4.59431, 2.5, 4.59431, 2.5, 10, 2.5, 10, -2.5, 10])
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
 	shape.width = 5
@@ -196,6 +196,7 @@ func test_regenerate__line_with_width_uses_drawn_arc_and_corner_size__shape_76_p
 	assert_almost_eq_deep(shape.shape.segments, expected_shape, Vector2.ONE * 0.001)
 
 func test_regenerate__line_with_width_drawn_arc_PI_uses_corner_size__shape_8_point_concave_shape():
+	var expected_shape := to_vector2s([-2.5, 10, -2.5, 6.12323e-16, -2.5, 6.12323e-16, 2.5, -6.12323e-16, 2.5, -6.12323e-16, 2.5, 10, 2.5, 10, -2.5, 10])
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
 	shape.width = 5
@@ -207,7 +208,7 @@ func test_regenerate__line_with_width_drawn_arc_PI_uses_corner_size__shape_8_poi
 	assert_true(shape.shape is ConcavePolygonShape2D, "Property 'shape' should be type ConcavePolygonShape2D")
 	if is_failing(): 
 		return
-	assert_eq(shape.shape.segments.size(), 8, "Property 'shape.segments' should have 8 points")
+	assert_almost_eq_deep(shape.shape.segments, expected_shape, Vector2.ONE * 0.001)
 
 func test_regenerate__uses_width__shape_concave_shape():
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -1,18 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+extends GutCollectionTest
 
 func assert_eq_shape(a : Shape2D, b : Shape2D, error_interval : float) -> void:
 	if a.get_class() != b.get_class():

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -121,9 +121,12 @@ func test_regenerate__vertices_count_2__shape_segment_shape():
 
 	assert_true(shape.shape is SegmentShape2D, "Property 'shape' should be type SegmentShape2D.")
 
-func test_regenerate__line_with_width_offset_rotation_multiples_of_PI__shape_rectangle_taller_than_wide(p = use_parameters([0, PI, -PI, TAU])):
+func test_regenerate__line_with_width_offset_rotation_multiples_of_PI__expected_shape(p = use_parameters([0, PI, -PI, TAU])):
+	var expected_shape := RectangleShape2D.new()
+	expected_shape.size = Vector2(5, 10)
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
+	shape.size = 10
 	shape.width = 5
 	shape.offset_rotation = p
 
@@ -132,11 +135,14 @@ func test_regenerate__line_with_width_offset_rotation_multiples_of_PI__shape_rec
 	assert_true(shape.shape is RectangleShape2D, "Property 'shape' should be type RectangleShape2D.")
 	if is_failing(): 
 		return
-	assert_gt(shape.shape.size.y, shape.shape.size.x, "Property 'shape' should be taller than wide")
+	assert_eq_shape(shape.shape, expected_shape, 0.001)
 
 func test_regenerate__line_with_width_offset_rotation_multiples_of_PI_plus_PI_over_2__shape_rectangle_wider_than_tall(p = use_parameters([PI / 2, -PI * 3 / 2, PI * 5 / 2])):
+	var expected_shape := RectangleShape2D.new()
+	expected_shape.size = Vector2(10, 5)
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
+	shape.size = 10
 	shape.width = 5
 	shape.offset_rotation = p
 
@@ -145,7 +151,7 @@ func test_regenerate__line_with_width_offset_rotation_multiples_of_PI_plus_PI_ov
 	assert_true(shape.shape is RectangleShape2D, "Property 'shape' should be type RectangleShape2D.")
 	if is_failing(): 
 		return
-	assert_gt(shape.shape.size.x, shape.shape.size.y, "Property 'shape' should be wider than tall")
+	assert_eq_shape(shape.shape, expected_shape, 0.001)
 
 func test_regenerate__line_with_width_offset_rotation_not_multiple_of_PI_over_2__shape_4_point_convex_shape(p = use_parameters([1, -3, 5])):
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
@@ -174,18 +180,20 @@ func test_regenerate__line_with_width_uses_drawn_arc__shape_16_point_concave_sha
 	assert_eq(shape.shape.segments.size(), 16, "Property 'shape.segments' should have 16 points")
 
 func test_regenerate__line_with_width_uses_drawn_arc_and_corner_size__shape_76_point_concave_shape():
+	var expected_shape := PackedVector2Array([Vector2(2.5, -10), Vector2(2.5, -5.40569), Vector2(2.5, -5.40569), Vector2(3.22642, -3.22642), Vector2(3.22642, -3.22642), Vector2(5.40569, -2.5), Vector2(5.40569, -2.5), Vector2(10, -2.5), Vector2(10, -2.5), Vector2(10, 2.5), Vector2(10, 2.5), Vector2(4.59431, 2.5), Vector2(4.59431, 2.5), Vector2(-0.726424, 0.726424), Vector2(-0.726424, 0.726424), Vector2(-2.5, -4.59431), Vector2(-2.5, -4.59431), Vector2(-2.5, -10), Vector2(-2.5, -10), Vector2(2.5, -10)])
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.vertices_count = 2
 	shape.width = 5
 	shape.drawn_arc = PI * 3 / 2
 	shape.corner_size = 5
+	shape.corner_smoothness = 2
 
 	shape.regenerate()
 
 	assert_true(shape.shape is ConcavePolygonShape2D, "Property 'shape' should be type ConcavePolygonShape2D")
 	if is_failing(): 
 		return
-	assert_eq(shape.shape.segments.size(), 76, "Property 'shape.segments' should have 76 points")
+	assert_almost_eq_deep(shape.shape.segments, expected_shape, Vector2.ONE * 0.001)
 
 func test_regenerate__line_with_width_drawn_arc_PI_uses_corner_size__shape_8_point_concave_shape():
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -1,19 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
-
+extends GutCollectionTest
 
 var class_script := preload("res://addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -103,11 +103,11 @@ func test_regenerate_polygon__holed_shape_with_drawn_arc__ends_not_equal():
 	assert_almost_ne(polygon[0], polygon[4], Vector2.ONE * 0.01, "The first and last points of the outer shape of the generated polygon.")
 	assert_almost_ne(polygon[5], polygon[9], Vector2.ONE * 0.01, "The first and last points of the inner ring of the generated polygon.")
 
-func test_get_shape_vertices__drawn_arc_PI__no_central_point(p = use_parameters([[PI], [-PI]])):
+func test_get_shape_vertices__drawn_arc_PI__no_central_point():
 	var expected := PackedVector2Array([Vector2(0, 7.07107), Vector2(-7.07107, 7.07107), Vector2(-7.07107, -7.07107), Vector2(0, -7.07107)])
 	var shape : PackedVector2Array
 
-	shape = RegularPolygon2D.get_shape_vertices(4, 10, 0, Vector2.ZERO, p[0])
+	shape = RegularPolygon2D.get_shape_vertices(4, 10, 0, Vector2.ZERO, PI)
 
 	assert_almost_ne(shape[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last element of the returned array.")
 	# assert_eq(shape.size(), 4, "Size of returned array.")
@@ -156,7 +156,7 @@ func test_add_hole_to_points__do_not_close_shape__expected_shape():
 	
 func test_add_hole_to_points__do_close_shape__expected_shape():
 	const sample_hole_scaler = 0.5
-	var shape := PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.RIGHT])
+	var shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10)])
 	var expected_shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10), Vector2(8.66025, 5), Vector2(4.33012, 2.5), Vector2(-6.12323e-16, -5), Vector2(-4.33013, 2.5), Vector2(4.33013, 2.5)])
 
 	RegularPolygon2D.add_hole_to_points(shape, sample_hole_scaler, true)

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -104,12 +104,14 @@ func test_regenerate_polygon__holed_shape_with_drawn_arc__ends_not_equal():
 	assert_almost_ne(polygon[5], polygon[9], Vector2.ONE * 0.01, "The first and last points of the inner ring of the generated polygon.")
 
 func test_get_shape_vertices__drawn_arc_PI__no_central_point(p = use_parameters([[PI], [-PI]])):
+	var expected := PackedVector2Array([Vector2(0, 7.07107), Vector2(-7.07107, 7.07107), Vector2(-7.07107, -7.07107), Vector2(0, -7.07107)])
 	var shape : PackedVector2Array
 
 	shape = RegularPolygon2D.get_shape_vertices(4, 10, 0, Vector2.ZERO, p[0])
 
 	assert_almost_ne(shape[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last element of the returned array.")
-	assert_eq(shape.size(), 4, "Size of returned array.")
+	# assert_eq(shape.size(), 4, "Size of returned array.")
+	assert_almost_eq_deep(shape, expected, Vector2.ONE * 0.001)
 
 func test_get_shape_vertices__false_central_point_when_drawn_arc_is_TAU_or_PI__no_central_point(p = use_parameters([[TAU], [PI], [-PI]])):
 	var shape : PackedVector2Array
@@ -143,23 +145,23 @@ func test_add_rounded_corners__very_small_corner_size__approximately_equal_vecto
 		assert_almost_eq(shape[index + 1], shape[index], Vector2.ONE * 0.1, "First part of corner of modified array.")
 		assert_almost_eq(shape[index + 2], shape[index], Vector2.ONE * 0.1, "Last part of corner of modified array.")
 
-func test_add_hole_to_points__do_not_close_shape__array_size_doubles():
-	var shape := PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.RIGHT])
-	var previous_size := shape.size()
+func test_add_hole_to_points__do_not_close_shape__expected_shape():
+	const sample_hole_scaler = 0.5
+	var shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10)])
+	var expected_shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10), Vector2(-6.12323e-16, -5), Vector2(-4.33013, 2.5), Vector2(4.33013, 2.5)])
 
-	RegularPolygon2D.add_hole_to_points(shape, 1, false)
-	var new_size := shape.size()
+	RegularPolygon2D.add_hole_to_points(shape, sample_hole_scaler, false)
 
-	assert_eq(new_size, 2 * previous_size, "Size of modified array, 2 * the original size.")
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.0001)
 	
-func test_add_hole_to_points__do_close_shape__array_size_doubles_plus_2():
+func test_add_hole_to_points__do_close_shape__expected_shape():
+	const sample_hole_scaler = 0.5
 	var shape := PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.RIGHT])
-	var previous_size := shape.size()
+	var expected_shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10), Vector2(8.66025, 5), Vector2(4.33012, 2.5), Vector2(-6.12323e-16, -5), Vector2(-4.33013, 2.5), Vector2(4.33013, 2.5)])
 
-	RegularPolygon2D.add_hole_to_points(shape, 1, true)
-	var new_size := shape.size()
+	RegularPolygon2D.add_hole_to_points(shape, sample_hole_scaler, true)
 
-	assert_eq(new_size, 2 * previous_size + 2, "Size of modified array, 2 + 2 * the original size")
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.0001)
 
 var params_transform_shape := [
 	[4, 10, 100, TAU, 0, 0],

--- a/tests/unit_tests/test_simple_polygon_2d.gd
+++ b/tests/unit_tests/test_simple_polygon_2d.gd
@@ -1,4 +1,4 @@
-extends GutTest
+extends GutCollectionTest
 
 func test_init__filled__variables_assigned():
 	var shape : SimplePolygon2D

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -1,18 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+extends GutCollectionTest
 
 var class_script := preload("res://addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -94,12 +94,12 @@ func test_get_star_vertices__drawn_arc_PI__no_central_point(p = use_parameters([
 	assert_eq(star.size(), 6, "Size of the returned array.")
 
 func test_get_star_vertices__add_central_point_false__expected_size_and_not_ZERO():
+	var expected_shape := PackedVector2Array([Vector2(-1.22465e-15, -10), Vector2(2.93893, -4.04508), Vector2(9.51057, -3.09017), Vector2(4.75528, 1.54508), Vector2(5.87785, 8.09017), Vector2(1.22465e-15, 5), Vector2(-5.87785, 8.09017), Vector2(-4.75528, 1.54508), Vector2(-6.34038, 0)])
 	var star : PackedVector2Array
 
 	star = StarPolygon2D.get_star_vertices(5, 10, 5, 0, Vector2.ZERO, PI * 3 / 2, false)
 
-	assert_almost_ne(star[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last point in the returned array.")
-	assert_eq(star.size(), 9, "Size of the returned array")
+	assert_almost_eq_deep(star, expected_shape, Vector2.ONE * 0.001)
 
 var params_transform_shape := [
 	[4, 10, 100, TAU, 0, 0],


### PR DESCRIPTION
Added [GutCollectionTest](tests/unit_tests/gut_collection_test.gd) to hold `assert_almost_eq_deep`. Other unit tests to inherit from it and use the method where possible.