### PR TITLE
Sync method and property names across nodes

### DIFF
--- a/addons/complex_shape_creation/MethodName.cs
+++ b/addons/complex_shape_creation/MethodName.cs
@@ -6,6 +6,7 @@ namespace ComplexShapeCreation.MemberNames;
 public static class MethodName
 {
     public static readonly StringName GetShapeVertices = new("get_shape_vertices");
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public static readonly StringName RegeneratePolygon = new("regenerate_polygon");
     public static readonly StringName UsesPolygonMember = new("uses_polygon_member");
     public static readonly StringName GetSideLength = new("get_side_length");

--- a/addons/complex_shape_creation/PropertyName.cs
+++ b/addons/complex_shape_creation/PropertyName.cs
@@ -16,6 +16,7 @@ public static class PropertyName
     public static readonly StringName DrawnArc = new("drawn_arc");
     public static readonly StringName CornerSize = new("corner_size");
     public static readonly StringName CornerSmoothness = new("corner_smoothness");
-    public static readonly StringName PointCount = new("point_count");
+    [Obsolete("Property name has been replaced, use 'VerticesCount' instead.", false)]
+    public static readonly StringName PointCount = new("vertices_count");
     public static readonly StringName InnerSize = new("inner_size");
 }

--- a/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
@@ -158,10 +158,23 @@ public class RegularPolygon2D
     public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>
+    /// Queues <see cref="Regenerate"/> for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+    /// </summary>
+    /// <remarks>
+    /// If this method is called when the node is outside the <see cref="SceneTree"/>, regeneration will be delayed to when the node enters the tree. 
+    /// Use <see cref="Regenerate"/> directly to force initialization.
+    /// </remarks>
+    public void QueueRegenerate() => Instance.Call(MethodName.QueueRegenerate);
+
+    /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.
     /// </summary>
+    public void Regenerate() => Instance.Call(MethodName.Regenerate);
+
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public void RegeneratePolygon() => Instance.Call(MethodName.RegeneratePolygon);
+
     /// <summary>
     /// Checks whether the current properties of this node will have it use <see cref="Polygon2D.Polygon">.
     /// </summary>

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -447,6 +447,7 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 
 # Returns the point at the given [param t] on the Bézier curve with the given [param start], [param end], and single [param control] point.
 ## [b][color=red]Warning[/color][/b]: This method is not meant to be used outside the class, and will be changed/made private in the future.
+## @deprecated
 static func quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -9,7 +9,7 @@ extends Polygon2D
 ## It uses methods like [method CanvasItem.draw_colored_polygon] or [method CanvasItem.draw_circle], or use [member Polygon2D.polygon].
 ## Certain properties with circles will use a 32-sided polygon instead.
 ## [br][br][b]Note[/b]: If the node is set to use [member Polygon2D.polygon] when it is outside the [SceneTree],
-## regeneration will be delayed to when it enters it. Use [method regenerate_polygon] to force regeneration.
+## regeneration will be delayed to when it enters it. Use [method regenerate] to force regeneration.
 
 ## The number of vertices in the regular shape. A value of [code]1[/code] creates a circle, and a value of [code]2[/code] creates a line.
 ## [br][br]Certain properties with circles will use a 32-sided polygon instead.
@@ -21,7 +21,7 @@ var vertices_count : int = 1:
 		if vertices_count == 2 and width > 0:
 			polygon = PackedVector2Array()
 			return
-		_pre_redraw()
+		queue_regenerate()
 
 ## The length from each corner to the center.
 @export_range(0.000001, 10, 0.001, "or_greater", "hide_slider")
@@ -29,7 +29,7 @@ var size : float = 10:
 	set(value):
 		assert(value > 0, "property 'size' must be greater than 0");
 		size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The offset rotation of the shape, in degrees.
 var offset_rotation_degrees : float = 0:
@@ -43,7 +43,7 @@ var offset_rotation_degrees : float = 0:
 var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 ## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size] and [member offset_rotation].
@@ -73,7 +73,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	if not scale_width and \
 		(width >= size and width < size / scale
 		or width < size and width >= size / scale):
-		regenerate_polygon()
+		regenerate()
 		return
 	
 	var points_per_corner := 0
@@ -106,7 +106,7 @@ var width : float = -0.001:
 			return
 
 		width = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The arc of the drawn shape, in degrees, cutting off beyond that arc. 
 ## Values greater than [code]360[/code] or [code]-360[/code] draws a full shape. It starts in the middle of the bottom edge of the shapes. 
@@ -130,7 +130,7 @@ var drawn_arc_degrees : float = 360:
 var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
-		_pre_redraw()
+		queue_regenerate()
 		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
@@ -142,7 +142,7 @@ var corner_size : float = 0.0:
 	set(value):
 		assert(value >= 0, "property 'corner_size' must be greater than or equal to 0")
 		corner_size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## How many lines make up each corner. A value of [code]0[/code] will use a value of [code]32[/code] divided by [member vertices_count].
 ## This only has an effect if [member corner_size] is used.
@@ -151,7 +151,7 @@ var corner_smoothness : int = 0:
 	set(value):
 		assert(value >= 0, "property 'corner_smoothness' must be greater than or equal to 0")
 		corner_smoothness = value
-		_pre_redraw()
+		queue_regenerate()
 
 # "_BLOCK_QUEUE" is used by _init to prevent regeneration of the shape when it is already set by PackedScene.instantiate().
 const _NOT_QUEUED = 0
@@ -160,9 +160,14 @@ const _BLOCK_QUEUE = 2
 
 var _queue_status : int = _NOT_QUEUED 
 
-# Called when shape properties are updated, before [method _draw]/[method queue_redraw]. Calls [method queue_redraw] automatically.
-# queue-like functionality - pauses, and only 1 call.
+## @deprecated
 func _pre_redraw() -> void:
+	queue_regenerate()
+
+## Queues [method regenerate] for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+## [br][br]If this method is called when the node is outside the [SceneTree], regeneration will be delayed to when the node enters the tree.
+## Call [method regenerate] directly to force initialization.
+func queue_regenerate() -> void:
 	if not uses_polygon_member():
 		# the setting the 'polygon' property already calls queue_redraw
 		queue_redraw()
@@ -180,11 +185,11 @@ func _pre_redraw() -> void:
 	_queue_status = _NOT_QUEUED
 	if not uses_polygon_member():
 		return
-	regenerate_polygon()
+	regenerate()
 
 func _enter_tree() -> void:
 	if _queue_status == _IS_QUEUED and uses_polygon_member():
-		regenerate_polygon()
+		regenerate()
 	_queue_status = _NOT_QUEUED
 
 func _draw() -> void:
@@ -272,9 +277,14 @@ func _draw() -> void:
 	
 	draw_colored_polygon(points, color)
 
+## see [method regenerate]
+## @deprecated
+func regenerate_polygon() -> void:
+	regenerate()
+
 ## Sets [member Polygon2D.polygon] using the properties of this node. 
 ## This method can be used when the node is outside the [SceneTree] to force the regeneration of [member Polygon2D.polygon].
-func regenerate_polygon() -> void:
+func regenerate() -> void:
 	_queue_status = _NOT_QUEUED
 	if drawn_arc == 0:
 		polygon = PackedVector2Array()

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -92,6 +92,9 @@ public partial class SimplePolygon2D
     public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
     public void ApplyTransformation(float rotation, float scale) => Instance.Call(MethodName.ApplyTransformation, rotation, scale);
 
+    /// <inheritdoc cref="CanvasItem.QueueRedraw"/>
+    public void QueueRedraw() => Instance.QueueRedraw();
+
     /// <summary>Creates and wraps a <see cref="SimplePolygon2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>
     /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -59,11 +59,11 @@ var offset_position : Vector2 = Vector2.ZERO:
 		offset_position = value
 		queue_redraw()
 
-## A method for consistency across other nodes. Equivalent to [method CanvasItem.queue_redraw].
+## A method for consistency across other nodes. [b]Equivalent to [method CanvasItem.queue_redraw].[/b]
 func queue_regenerate() -> void:
 	queue_redraw()
 
-## A method for consistency across other nodes, and does not even regenerate the shape immediately. Equivalent to [method CanvasItem.queue_redraw].
+## A method for consistency across other nodes, and does not even regenerate the shape immediately. [b]Equivalent to [method CanvasItem.queue_redraw].[/b]
 func regenerate() -> void:
 	queue_redraw()
 

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -59,6 +59,14 @@ var offset_position : Vector2 = Vector2.ZERO:
 		offset_position = value
 		queue_redraw()
 
+## A method for consistency across other nodes. Equivalent to [method CanvasItem.queue_redraw].
+func queue_regenerate() -> void:
+	queue_redraw()
+
+## A method for consistency across other nodes, and does not even regenerate the shape immediately. Equivalent to [method CanvasItem.queue_redraw].
+func regenerate() -> void:
+	queue_redraw()
+
 func _draw() -> void:
 	if (vertices_count == 1):
 		draw_circle(offset_position, size, color)

--- a/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
+++ b/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
@@ -24,6 +24,12 @@ public class StarPolygon2D
     /// The number of points the star has.
     /// </summary>
     /// <remarks>If set to <c>1</c>, a line is drawn.</remarks>
+    public int VerticesCount
+    {
+        get => (int)Instance.Get(PropertyName.VerticesCount);
+        set => Instance.Set(PropertyName.VerticesCount, value);
+    }
+    [Obsolete("Property name has been replaced, use 'VerticesCount' instead.", false)]
     public int PointCount
     {
         get => (int)Instance.Get(PropertyName.PointCount);
@@ -144,11 +150,25 @@ public class StarPolygon2D
     /// Sets <see cref="innerSize"/> such that the angle formed by each point is equivalent to <paramref name="angle"/>, in radians.
     /// </summary>
     public void SetPointAngle(float angle) => Instance.Call(MethodName.SetPointAngle, angle);
+
+    /// <summary>
+    /// Queues <see cref="Regenerate"/> for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+    /// </summary>
+    /// <remarks>
+    /// If this method is called when the node is outside the <see cref="SceneTree"/>, regeneration will be delayed to when the node enters the tree. 
+    /// Use <see cref="Regenerate"/> directly to force initialization.
+    /// </remarks>
+    public void QueueRegenerate() => Instance.Call(MethodName.QueueRegenerate);
+
     /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.
     /// </summary>
+    public void Regenerate() => Instance.Call(MethodName.Regenerate);
+
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public void RegeneratePolygon() => Instance.Call(MethodName.RegeneratePolygon);
+
     /// <summary>
     /// Checks whether the current properties of this node will have it use <see cref="Polygon2D.Polygon">.
     /// </summary>

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -8,19 +8,27 @@ class_name StarPolygon2D
 ## A node that draws star, with complex properties.
 ## It uses [method CanvasItem.draw_colored_polygon], [method CanvasItem.draw_polyline], or [member Polygon2D.polygon]
 ## [br][br][b]Note[/b]: If the node is set to use [member Polygon2D.polygon] when it is outside the [SceneTree],
-## regeneration will be delayed to when it enters it. Use [method regenerate_polygon] to force regeneration.
+## regeneration will be delayed to when it enters it. Use [method regenerate] to force regeneration.
 
 ## The number of points the star has.
 ## [br][br]If set to [code]1[/code], a line is drawn.
+var vertices_count : int = 5:
+	set(value):
+		assert(value > 0, "property 'vertices_count' must be greater than 0")
+		vertices_count = value
+		if vertices_count == 1 and width > 0:
+			polygon = PackedVector2Array()
+			return
+		queue_regenerate()
+
+## see [member vertices_count]
+## @deprecated
 @export_range(1, 2000)
 var point_count : int = 5:
 	set(value):
-		assert(value > 0, "property 'point_count' must be greater than 0")
-		point_count = value
-		if point_count == 1 and width > 0:
-			polygon = PackedVector2Array()
-			return
-		_pre_redraw()
+		vertices_count = value
+	get:
+		return vertices_count
 		
 ## The length of each point to the center of the star.
 ## [br][br]For lines, it determines the length of the top part.
@@ -29,7 +37,7 @@ var size : float = 10.0:
 	set(value):
 		assert(value > 0, "property 'size' must be greater than 0");
 		size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The length of the inner vertices to the center of the star.
 ## [br][br]For lines, it determines the length of the bottom part.
@@ -38,7 +46,7 @@ var inner_size : float = 5.0:
 	set(value):
 		assert(value > 0, "property 'inner_size' must be greater than 0");
 		inner_size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The offset rotation of the star, in degrees.
 var offset_rotation_degrees : float = 0:
@@ -52,7 +60,7 @@ var offset_rotation_degrees : float = 0:
 var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 ## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
@@ -83,12 +91,12 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	if not scale_width and \
 		(width >= size and width < size / scale
 		or width < size and width >= size / scale):
-		regenerate_polygon()
+		regenerate()
 		return
 	
 	var points_per_corner := 0
 	if corner_size > 0:
-		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / point_count 
+		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / vertices_count 
 	points_per_corner += 1
 	
 	var shape := polygon
@@ -114,7 +122,7 @@ var width : float = -0.001:
 			return
 
 		width = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The arc of the drawn star, in degrees, cutting off beyond that arc. 
 ## Values greater than [code]360[/code] or [code]-360[/code] draws a full star. It starts at the top point.
@@ -138,7 +146,7 @@ var drawn_arc_degrees : float = 360:
 var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
-		_pre_redraw()
+		queue_regenerate()
 		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
@@ -150,22 +158,22 @@ var corner_size : float = 0.0:
 	set(value):
 		assert(value >= 0, "property 'corner_size' must be greater than or equal to 0")
 		corner_size = value
-		_pre_redraw()
+		queue_regenerate()
 
-## How many lines make up each corner. A value of [code]0[/code] will use a value of [code]32[/code] divided by [member point_count].
+## How many lines make up each corner. A value of [code]0[/code] will use a value of [code]32[/code] divided by [member vertices_count].
 ## This only has an effect if [member corner_size] is used.
 @export_range(0, 8, 1, "or_greater") 
 var corner_smoothness : int = 0:
 	set(value):
 		assert(value >= 0, "property 'corner_smoothness' must be greater than or equal to 0")
 		corner_smoothness = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## Sets [member inner_size] such that the angle formed by each point is equivalent to [param angle], in radians.
 func set_point_angle(angle : float) -> void:
 	assert(0 < angle and angle < TAU, "param 'angle' must be between 0 and TAU")
 	angle /= 2
-	inner_size = size * sin(angle / (sin(PI - angle - TAU / point_count / 2)))
+	inner_size = size * sin(angle / (sin(PI - angle - TAU / vertices_count / 2)))
 
 # "_BLOCK_QUEUE" is used by _init to prevent regeneration of the shape when it is already set by PackedScene.instantiate().
 const _NOT_QUEUED = 0
@@ -174,7 +182,14 @@ const _BLOCK_QUEUE = 2
 
 var _queue_status : int = _NOT_QUEUED 
 
+## @deprecated
 func _pre_redraw() -> void:
+	queue_regenerate()
+
+## Queues [method regenerate] for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+## [br][br]If this method is called when the node is outside the [SceneTree], regeneration will be delayed to when the node enters the tree.
+## Call [method regenerate] directly to force initialization.
+func queue_regenerate() -> void:
 	if not uses_polygon_member():
 		# the setting the 'polygon' property already calls queue_redraw
 		queue_redraw()
@@ -192,18 +207,18 @@ func _pre_redraw() -> void:
 	_queue_status = _NOT_QUEUED
 	if not uses_polygon_member():
 		return
-	regenerate_polygon()
+	regenerate()
 
 func _enter_tree() -> void:
 	if _queue_status == _IS_QUEUED and uses_polygon_member():
-		regenerate_polygon()
+		regenerate()
 	_queue_status = _NOT_QUEUED
 
 func _draw():
 	if uses_polygon_member() or drawn_arc == 0:
 		return
 	
-	if point_count == 1:
+	if vertices_count == 1:
 		var point := -_get_vertices(offset_rotation + drawn_arc, size)
 		var width_value = width if width != 0 else -1
 		if drawn_arc <= -TAU or drawn_arc >= TAU:
@@ -232,10 +247,10 @@ func _draw():
 		draw_polyline(line, color, width_value, antialiased)
 		return
 	
-	var points := get_star_vertices(point_count, size, inner_size, offset_rotation, offset, drawn_arc)
+	var points := get_star_vertices(vertices_count, size, inner_size, offset_rotation, offset, drawn_arc)
 
 	if not is_zero_approx(corner_size):
-		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count)
+		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count)
 
 	if is_zero_approx(width):
 		points.append(points[0])
@@ -262,9 +277,14 @@ func _draw():
 		return
 	draw_colored_polygon(points, color);
 	
+## see [method regenerate].
+## @deprecated
+func regenerate_polygon() -> void:
+	regenerate()
+
 ## Sets [member Polygon2D.polygon] using the properties of this node. 
 ## This method can be used when the node is outside the [SceneTree] to force this, and ignores the result of [method uses_polygon_member].
-func regenerate_polygon():
+func regenerate() -> void:
 	_queue_status = _NOT_QUEUED
 	if drawn_arc == 0:
 		polygon = PackedVector2Array()
@@ -272,12 +292,12 @@ func regenerate_polygon():
 	
 	var uses_width := width < size
 	var uses_drawn_arc := -TAU < drawn_arc and drawn_arc < TAU
-	var points = StarPolygon2D.get_star_vertices(point_count, size, inner_size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
+	var points = StarPolygon2D.get_star_vertices(vertices_count, size, inner_size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
 	if uses_width:
 		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, not uses_drawn_arc)
 
 	if not is_zero_approx(corner_size):
-		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count, uses_width and not uses_drawn_arc)
+		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count, uses_width and not uses_drawn_arc)
 	
 	polygon = points
 	
@@ -287,7 +307,7 @@ func _init(vertices_count : int = 1, size := 10.0, inner_size := 5.0, offset_rot
 		_queue_status = _BLOCK_QUEUE
 
 	if vertices_count != 1:
-		self.point_count = vertices_count
+		self.vertices_count = vertices_count
 	if size != 10.0:
 		self.size = size
 	if inner_size != 5.0:
@@ -316,16 +336,16 @@ func _get_configuration_warnings() -> PackedStringArray:
 func uses_polygon_member() -> bool:
 	return (
 		width > 0
-		and point_count != 1
+		and vertices_count != 1
 	)
 
 ## Returns a [PackedVector2Array] with points for forming the specified star.
 ## [br][br][param add_central_point] adds [param offset_rotation] at the end of the array. 
 ## It only has an effect if [param drawn_arc] is used and isn't ±[constant @GDSCript.PI].
 ## It should be set to false when using [method RegularPolygon2D.add_hole_to_points].
-static func get_star_vertices(point_count : int, size : float, inner_size : float, offset_rotation := 0.0, offset_position := Vector2.ZERO,
+static func get_star_vertices(vertices_count : int, size : float, inner_size : float, offset_rotation := 0.0, offset_position := Vector2.ZERO,
 	drawn_arc := TAU, add_central_point := true) -> PackedVector2Array:
-	assert(point_count > 1, "param 'point_count' must be greater than 1")
+	assert(vertices_count > 1, "param 'vertices_count' must be greater than 1")
 	assert(size > 0, "param 'size' must be greater than 0")
 	assert(inner_size > 0, "param 'inner_size' must be greater than 0")
 	assert(drawn_arc != 0, "param 'drawn_arc' cannot be 0")
@@ -333,10 +353,10 @@ static func get_star_vertices(point_count : int, size : float, inner_size : floa
 	var points := PackedVector2Array()
 	offset_rotation += PI
 	if drawn_arc >= TAU or drawn_arc <= -TAU:
-		points.resize(point_count * 2)
+		points.resize(vertices_count * 2)
 		var current_rotation := offset_rotation
-		var rotation_spacing := TAU / point_count / 2
-		for i in point_count:	
+		var rotation_spacing := TAU / vertices_count / 2
+		for i in vertices_count:	
 			points[i * 2] = Vector2(-sin(current_rotation), cos(current_rotation)) * size + offset_position
 			current_rotation += rotation_spacing
 			points[i * 2 + 1] = Vector2(-sin(current_rotation), cos(current_rotation)) * inner_size + offset_position
@@ -344,7 +364,7 @@ static func get_star_vertices(point_count : int, size : float, inner_size : floa
 		return points
 	
 	var sign := signf(drawn_arc)
-	var rotation_spacing := TAU / point_count * sign
+	var rotation_spacing := TAU / vertices_count * sign
 	var half_rotation_spacing := rotation_spacing / 2
 	var original_vertices_count := floori(drawn_arc / half_rotation_spacing)
 	var ends_on_vertex := is_equal_approx(drawn_arc, original_vertices_count * half_rotation_spacing)

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -159,8 +159,8 @@ public class RegularPolygon2DTests : TestClass
     {
         const float rotationAmount = 1.2f;
         const float sizeScale = 2;
-        RegularPolygon2D expected = new(4, 10, 0);
-        RegularPolygon2D sample = new(4, 10, 0);
+        RegularPolygon2D expected = new(4, width: 100);
+        RegularPolygon2D sample = new(4, width: 100);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
         expected.Regenerate();

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -97,11 +97,24 @@ public class RegularPolygon2DTests : TestClass
     }
 
     [Test]
-    public void RegeneratePolygon_PolygonSetEmpty_PolygonFilled()
+    public async System.Threading.Tasks.Task QueueRegenerate_PolygonSetEmpty_PolygonFilled()
+    {
+        TestScene.AddChild(polygon);
+        polygon.Instance.Polygon = System.Array.Empty<Vector2>();
+
+        polygon.QueueRegenerate();
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+
+        polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public void Regenerate_PolygonSetEmpty_PolygonFilled()
     {
         polygon.Instance.Polygon = System.Array.Empty<Vector2>();
 
-        polygon.RegeneratePolygon();
+        polygon.Regenerate();
 
         polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
     }
@@ -150,8 +163,8 @@ public class RegularPolygon2DTests : TestClass
         RegularPolygon2D sample = new(4, 10, 0);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
-        expected.RegeneratePolygon();
-        sample.RegeneratePolygon();
+        expected.Regenerate();
+        sample.Regenerate();
 
         sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -16,11 +16,11 @@ public class StarPolygon2DTests : TestClass
     }
 
     [Test]
-    public void PointCount_Set3_Returns3()
+    public void VerticesCount_Set3_Returns3()
     {
-        polygon.PointCount = 3;
+        polygon.VerticesCount = 3;
         
-        polygon.PointCount.ShouldBe(3);
+        polygon.VerticesCount.ShouldBe(3);
     }
 
     [Test]
@@ -113,13 +113,24 @@ public class StarPolygon2DTests : TestClass
 
         result.ShouldBe(true);
     }
+    public async System.Threading.Tasks.Task QueueRegenerate_PolygonSetEmpty_PolygonFilled()
+    {
+        TestScene.AddChild(polygon);
+        polygon.Instance.Polygon = System.Array.Empty<Vector2>();
+
+        polygon.QueueRegenerate();
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+
+        polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
+    }
 
     [Test]
-    public void RegeneratePolygon_PolygonSetEmpty_PolygonFilled()
+    public void Regenerate_PolygonSetEmpty_PolygonFilled()
     {
         polygon.Instance.Polygon = System.Array.Empty<Vector2>();
 
-        polygon.RegeneratePolygon();
+        polygon.Regenerate();
 
         polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
     }

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -113,6 +113,8 @@ public class StarPolygon2DTests : TestClass
 
         result.ShouldBe(true);
     }
+    
+    [Test]
     public async System.Threading.Tasks.Task QueueRegenerate_PolygonSetEmpty_PolygonFilled()
     {
         TestScene.AddChild(polygon);
@@ -148,12 +150,12 @@ public class StarPolygon2DTests : TestClass
     {
         const float rotationAmount = 1.2f;
         const float sizeScale = 2;
-        RegularPolygon2D expected = new(4, 10, 0);
-        RegularPolygon2D sample = new(4, 10, 0);
+        StarPolygon2D expected = new(4, 10, 0);
+        StarPolygon2D sample = new(4, 10, 0);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
-        expected.RegeneratePolygon();
-        sample.RegeneratePolygon();
+        expected.Regenerate();
+        sample.Regenerate();
 
         sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -150,8 +150,8 @@ public class StarPolygon2DTests : TestClass
     {
         const float rotationAmount = 1.2f;
         const float sizeScale = 2;
-        StarPolygon2D expected = new(4, 10, 0);
-        StarPolygon2D sample = new(4, 10, 0);
+        StarPolygon2D expected = new(5, width: 100);
+        StarPolygon2D sample = new(5, width: 100);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
         expected.Regenerate();

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -13,7 +13,7 @@ func test_init__params_filled__assigned_to_vars():
 
 	star = autoqfree(StarPolygon2D.new(3, 5.0, 1.0, 1.0, Color.RED, Vector2.ONE, 1.0, 1.0, 1.0, 1))
 
-	assert_eq(star.point_count, 3, "Property 'point_count'.")
+	assert_eq(star.vertices_count, 3, "Property 'vertices_count'.")
 	assert_eq(star.size, 5.0, "Property 'size'.")
 	assert_eq(star.inner_size, 1.0, "Property 'inner_size'.")
 	assert_eq(star.offset_rotation, 1.0, "Property 'offset_rotation'.")
@@ -44,13 +44,13 @@ func test_init__polygon_empty__queue_not_blocked():
 
 func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : StarPolygon2D = partial_double(class_script).new()
-	stub(shape, "regenerate_polygon").to_do_nothing()
+	stub(shape, "regenerate").to_do_nothing()
 	shape.polygon = sample_polygon
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
 
 	shape._enter_tree()
 
-	assert_not_called(shape, "regenerate_polygon") # does not accept a custom message.
+	assert_not_called(shape, "regenerate") # does not accept a custom message.
 
 func test_enter_tree__not_not_queued__now_not_queued(p= use_parameters([StarPolygon2D._IS_QUEUED, StarPolygon2D._BLOCK_QUEUE])):
 	var shape : StarPolygon2D = partial_double(class_script).new()
@@ -66,7 +66,7 @@ func test_pre_redraw__not_queued__is_queued():
 	star.polygon = sample_polygon
 	star._queue_status = StarPolygon2D._NOT_QUEUED
 
-	star._pre_redraw()
+	star.queue_regenerate()
 
 	assert_eq(star._queue_status, StarPolygon2D._IS_QUEUED, "Property '_queue_status' should be '_IS_QUEUED' (1).")
 
@@ -77,7 +77,7 @@ func test_queue_regenerate__in_tree__delayed_shape_filled():
 	stub(star, "_enter_tree").to_do_nothing()
 	add_child(star)
 
-	star._pre_redraw()
+	star.queue_regenerate()
 
 	assert_true(star.polygon.is_empty(), "Variable 'polygon' should still be an empty array.")
 	await wait_for_signal(get_tree().process_frame, 10)
@@ -114,7 +114,7 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -124,67 +124,67 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 3
 	var expected := StarPolygon2D.new()
-	expected.point_count = 4
+	expected.vertices_count = 4
 	expected.width = 15
-	expected.regenerate_polygon()
+	expected.regenerate()
 	autoqfree(expected)
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = 4
+	shape.vertices_count = 4
 	shape.width = 15
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	shape.polygon = expected.polygon
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(0, sample_scale_amount, false, false)
 
-	assert_called(shape, "regenerate_polygon")
+	assert_called(shape, "regenerate")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
 func test_apply_transformation__size_change_removes_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 0.2
 	var expected := StarPolygon2D.new()
-	expected.point_count = 4
+	expected.vertices_count = 4
 	expected.width = 5
-	expected.regenerate_polygon()
+	expected.regenerate()
 	autoqfree(expected)
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = 4
+	shape.vertices_count = 4
 	shape.width = 5
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	shape.polygon = expected.polygon
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(0, sample_scale_amount, false, false)
 
-	assert_called(shape, "regenerate_polygon")
+	assert_called(shape, "regenerate")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
 func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(params_transform_shape)):
@@ -192,7 +192,7 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -202,32 +202,32 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.width *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
 	const sample_scale_amount := 2.3
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -237,32 +237,32 @@ func test_apply_transformation__corner_size_scaled__expected_shape(p=use_paramet
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.corner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, true)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
 	const sample_scale_amount := 2.3
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -272,23 +272,23 @@ func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=u
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.width *= sample_scale_amount
 	expected.corner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, true)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")


### PR DESCRIPTION
Method and property names have been made consistent with each other across nodes, renaming and making some methods public. Old methods have been retained but have been marked `@deprecated`/`[Obsolete]`, and will be removed in the near future.
Changes:
--`StarPolygon2D`--
- `point_count` > `vertices_count`
- `queue_regenerate()` +
- `regenerate_polygon()` > `regenerate()`


--`RegularPolygon2D`--
- `queue_regenerate()` +
- `regenerate_polygon()` > `regenerate()`
- `quadratic_bezier_interpolate()` has been marked as deprecated. 


--`SimplePolygon2D`--
**Note**: These are equivalent to simply calling `queue_redraw`, and so these methods do not show up in the C# Wrapper classes. Instead, `QueueRedraw` has been exposed instead.
- `queue_regenerate()` +
- `regenerate()` +

