### PR TITLE
Release 2.1.1

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,24 @@
+This is a copy of the [license](addons/complex_shape_creation/LICENSE.txt) found in the addon's folder.
+```
+MIT License
+
+Copyright (c) 2024 9thAzure (GitHub username)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Regular Polygon 2D icon](/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.svg)
 
 ![GitHub Release](https://img.shields.io/github/v/release/9thAzure/Complex_Shape_Creation)
-![Static Badge (License, not detected by github because it is in sub folder)](https://img.shields.io/badge/License-MIT-orange)
+![GitHub License](https://img.shields.io/github/license/9thAzure/Complex_Shape_Creation)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/9thAzure/Complex_Shape_Creation)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/9thAzure/Complex_Shape_Creation/total)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ All other functions **modify** the array passed in as the argument.
 ## License
 
 This addon is available under the [MIT](https://mit-license.org/) license,
-which is in the addon's [folder](/addons/complex_shape_creation/LICENSE.txt)
+which is in the addon's [folder](/addons/complex_shape_creation/LICENSE.txt).
+A copy is available in the root [folder](/License.md).
 
 ## Plugins / Packages Used
 

--- a/addons/complex_shape_creation/MethodName.cs
+++ b/addons/complex_shape_creation/MethodName.cs
@@ -6,6 +6,7 @@ namespace ComplexShapeCreation.MemberNames;
 public static class MethodName
 {
     public static readonly StringName GetShapeVertices = new("get_shape_vertices");
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public static readonly StringName RegeneratePolygon = new("regenerate_polygon");
     public static readonly StringName UsesPolygonMember = new("uses_polygon_member");
     public static readonly StringName GetSideLength = new("get_side_length");

--- a/addons/complex_shape_creation/MethodName.cs
+++ b/addons/complex_shape_creation/MethodName.cs
@@ -20,4 +20,5 @@ public static class MethodName
     public static readonly StringName GetStarVertices = new("get_star_vertices");
     public static readonly StringName WidenPolyline = new("_widen_polyline_result");
     public static readonly StringName WidenMultiline = new("_widen_multiline_result");
+    public static readonly StringName ApplyTransformation = new("apply_transformation");
 }

--- a/addons/complex_shape_creation/PropertyName.cs
+++ b/addons/complex_shape_creation/PropertyName.cs
@@ -16,6 +16,7 @@ public static class PropertyName
     public static readonly StringName DrawnArc = new("drawn_arc");
     public static readonly StringName CornerSize = new("corner_size");
     public static readonly StringName CornerSmoothness = new("corner_smoothness");
-    public static readonly StringName PointCount = new("point_count");
+    [Obsolete("Property name has been replaced, use 'VerticesCount' instead.", false)]
+    public static readonly StringName PointCount = new("vertices_count");
     public static readonly StringName InnerSize = new("inner_size");
 }

--- a/addons/complex_shape_creation/PropertyName.cs
+++ b/addons/complex_shape_creation/PropertyName.cs
@@ -10,7 +10,9 @@ public static class PropertyName
     public static readonly StringName OffsetRotationDegrees = new("offset_rotation_degrees");
     public static readonly StringName OffsetRotation = new("offset_rotation");
     public static readonly StringName Color = new("color");
+    [Obsolete("Property name has been replaced, use 'Offset' instead.", false)]
     public static readonly StringName OffsetPosition = new("offset_position");
+    public static readonly StringName Offset = new("offset");
     public static readonly StringName Width = new("width");
     public static readonly StringName DrawnArcDegrees = new("drawn_arc_degrees");
     public static readonly StringName DrawnArc = new("drawn_arc");

--- a/addons/complex_shape_creation/gui_handlers/base_handler.gd
+++ b/addons/complex_shape_creation/gui_handlers/base_handler.gd
@@ -1,0 +1,132 @@
+@tool
+extends Node2D 
+
+var _shift_clamps : Array[Callable] = [clamp_straight_line, clamp_circle_radius, clamp_compass_lines]
+
+var _plugin : EditorPlugin
+var _undo_redo_manager : EditorUndoRedoManager
+var _parent : Node2D = null
+var _origin := Vector2.ZERO
+var size := 1.0
+
+var _being_dragged := false
+var _old_position := Vector2.ZERO
+
+
+func _init(plugin : EditorPlugin, undo_redo_manager : EditorUndoRedoManager, handler_size := 9.0) -> void:
+	_plugin = plugin
+	_undo_redo_manager = undo_redo_manager
+	_undo_redo_manager.version_changed.connect(maintain_shape)
+	_undo_redo_manager.history_changed.connect(maintain_shape)
+	size = handler_size
+
+func _ready() -> void:
+	assert(Engine.is_editor_hint())
+
+	_parent = get_parent()
+
+	maintain_shape()
+
+func mouse_press(point : Vector2) -> bool:
+	const extra_margin := 2.0
+	if (point - global_position).length_squared() <= ((size + extra_margin) / get_viewport_transform().get_scale().x) ** 2:
+		_old_position = position
+		_being_dragged = true
+		if _old_position == Vector2.ZERO:
+			_old_position = Vector2.RIGHT
+		modulate = Color.LIME_GREEN
+		return true
+	return false
+
+var suppress_from_parent_call := false
+func mouse_release() -> bool:
+	if _being_dragged:
+		_being_dragged = false
+		suppress_from_parent_call = true
+		_mouse_released()
+		modulate = Color.WHITE
+		return true
+	return false
+
+func _from_parent_properties() -> void:
+	printerr("'_from_parent_properties' is abstract")
+
+func _update_properties() -> void:
+	printerr("'_update_properties' is abstract")
+
+func _mouse_released() -> void:
+	printerr("'_mouse_released' is abstract")
+
+func _draw() -> void:
+	const margin := 1
+
+	var shape := RegularPolygon2D.get_shape_vertices(5, size)
+	draw_colored_polygon(shape, Color.WHITE)
+	draw_polyline(shape, Color.BLACK, margin, true)
+	draw_line(shape[-1], shape[0], Color.BLACK, margin, true)
+
+var previous_editor_scale := 1.0
+func _process(_delta) -> void:
+	var editor_scale := get_viewport_transform().get_scale().x
+	if not is_equal_approx(editor_scale, previous_editor_scale):
+		maintain_editor_scale()
+		previous_editor_scale = editor_scale
+
+	if not _being_dragged:
+		return
+
+	global_position = get_global_mouse_position()
+	if Input.is_key_pressed(KEY_SHIFT):
+		_clamp_position()
+	_update_properties()
+	
+func maintain_shape() -> void:
+	if suppress_from_parent_call:
+		suppress_from_parent_call = false
+		return
+
+	_origin = Vector2.ZERO
+	if not _parent is CollisionShape2D:
+		_origin = _parent.offset
+	_from_parent_properties()
+
+func maintain_editor_scale() -> void:
+	global_transform = Transform2D(0, Vector2.ONE / get_viewport_transform().get_scale().x, 0, global_position)
+
+func _clamp_position() -> void:
+	if _shift_clamps.size() == 0:
+		return
+	
+	var best_position := position
+	var best_distance := INF
+	for i in _shift_clamps.size():
+		var point = _shift_clamps[i].call()
+		if typeof(point) != TYPE_VECTOR2:
+			printerr("method %s did not returned a %s, not a vector2." % [_shift_clamps[i], typeof(point)])		
+			continue
+		
+		var distance : float = (point - position).length_squared()
+		if distance < best_distance:
+			best_distance = distance
+			best_position = point
+	
+	position = best_position
+
+func clamp_straight_line() -> Vector2:
+	var allowed_line := _old_position - _origin
+	var inverse_line := Vector2(-allowed_line.y, allowed_line.x)
+	var a := RegularGeometry2D._find_intersection(position, inverse_line, _origin, allowed_line)
+	return position + inverse_line * a
+
+func clamp_circle_radius() -> Vector2:
+	var radius := (_old_position - _origin).length()
+	return _origin + (position - _origin).normalized() * radius
+
+func clamp_compass_lines() -> Vector2:
+	var functional_position := position - _origin
+	var angle := atan2(functional_position.y, functional_position.x)
+	var multiplier := floor((angle + TAU / 16) / (TAU / 8))
+
+	angle = multiplier * TAU / 8
+	var slope := Vector2(cos(angle), sin(angle))
+	return Geometry2D.get_closest_point_to_segment_uncapped(position, _origin, _origin + slope)

--- a/addons/complex_shape_creation/gui_handlers/base_handler.gd
+++ b/addons/complex_shape_creation/gui_handlers/base_handler.gd
@@ -16,16 +16,21 @@ var _old_position := Vector2.ZERO
 func _init(plugin : EditorPlugin, undo_redo_manager : EditorUndoRedoManager, handler_size := 9.0) -> void:
 	_plugin = plugin
 	_undo_redo_manager = undo_redo_manager
-	_undo_redo_manager.version_changed.connect(maintain_shape)
-	_undo_redo_manager.history_changed.connect(maintain_shape)
+	_undo_redo_manager.version_changed.connect(maintain_position)
+	_undo_redo_manager.version_changed.connect(maintain_editor_scale)
+	_undo_redo_manager.history_changed.connect(maintain_position)
+	_undo_redo_manager.history_changed.connect(maintain_editor_scale)
 	size = handler_size
+	z_as_relative = false
+	z_index = RenderingServer.CANVAS_ITEM_Z_MAX
 
 func _ready() -> void:
 	assert(Engine.is_editor_hint())
 
 	_parent = get_parent()
 
-	maintain_shape()
+	maintain_editor_scale()
+	maintain_position()
 
 func mouse_press(point : Vector2) -> bool:
 	const extra_margin := 2.0
@@ -80,7 +85,7 @@ func _process(_delta) -> void:
 		_clamp_position()
 	_update_properties()
 	
-func maintain_shape() -> void:
+func maintain_position() -> void:
 	if suppress_from_parent_call:
 		suppress_from_parent_call = false
 		return

--- a/addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd
+++ b/addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd
@@ -1,0 +1,61 @@
+@tool
+extends "res://addons/complex_shape_creation/gui_handlers/base_handler.gd"
+
+var shape_type : int = 0
+
+const _SHAPE_SIMPLE := 1
+const _SHAPE_REGULAR := 2
+const _SHAPE_STAR := 3
+const _SHAPE_COLLISION := 4
+
+func _ready() -> void:
+	shape_type = _get_shape_type(get_parent())
+	super._ready()
+	
+func _get_shape_type(shape : Node2D) -> int:
+	if shape is SimplePolygon2D:
+		return _SHAPE_SIMPLE
+	if shape is RegularPolygon2D:
+		return _SHAPE_REGULAR
+	if shape is StarPolygon2D:
+		return _SHAPE_STAR
+	if shape is RegularCollisionPolygon2D:
+		return _SHAPE_COLLISION
+			
+	printerr("unrecognized shape given: %s" % shape)
+	return 0
+
+func _from_parent_properties() -> void:
+	var offset_rotation : float = _parent.offset_rotation + get_rotation_offset()
+	
+	position = _origin + Vector2(sin(offset_rotation), -cos(offset_rotation)) * _parent.size
+
+func _update_properties() -> void:
+	var functional_position := position - _origin
+	_parent.size = functional_position.length()
+	_parent.offset_rotation = fmod(atan2(functional_position.y, functional_position.x) + PI / 2 - get_rotation_offset() + TAU, TAU)
+
+func _mouse_released() -> void:
+	_undo_redo_manager.create_action("Resizing and Rotating Shape")
+
+	_undo_redo_manager.add_do_property(_parent, &"size", _parent.size)
+	_undo_redo_manager.add_do_property(_parent, &"offset_rotation", _parent.offset_rotation)
+
+	var old_functional_position := (_old_position - _origin)
+	var old_size = old_functional_position.length()
+	var old_rotation = fmod(atan2(old_functional_position.y, old_functional_position.x) + PI / 2 - get_rotation_offset() + TAU, TAU)
+	_undo_redo_manager.add_undo_property(_parent, &"size", old_size)
+	_undo_redo_manager.add_undo_property(_parent, &"offset_rotation", old_rotation)
+
+	_undo_redo_manager.commit_action()
+
+func get_rotation_offset() -> float:
+	var offset := 0.0
+	if not is_parent_star_shape():
+		offset += PI
+		if _parent.vertices_count != 2:
+			offset += TAU / _parent.vertices_count / 2
+	return offset
+
+func is_parent_star_shape() -> bool:
+	return shape_type == _SHAPE_STAR or shape_type == _SHAPE_COLLISION and _parent.inner_size > 0

--- a/addons/complex_shape_creation/plugin.gd
+++ b/addons/complex_shape_creation/plugin.gd
@@ -23,7 +23,7 @@ func _edit(object : Object) -> void:
 		if parent != null:
 			parent.remove_child(_size_rotation_handler)
 		_size_rotation_handler.request_ready()
-		object.add_child(_size_rotation_handler, false, INTERNAL_MODE_FRONT)
+		object.add_child(_size_rotation_handler, false, INTERNAL_MODE_BACK)
 
 const BaseHandler := preload("res://addons/complex_shape_creation/gui_handlers/base_handler.gd")
 const SizeRotationHandler := preload("res://addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd")
@@ -46,6 +46,9 @@ func _forward_canvas_gui_input(event) -> bool:
 			return false
 		
 		if event.pressed:
+			if not _select_mode_button_selected():
+				return false
+
 			var viewport := EditorInterface.get_editor_viewport_2d()
 			var transform := viewport.get_final_transform()
 			var size := viewport.size
@@ -61,3 +64,35 @@ func _forward_canvas_gui_input(event) -> bool:
 			return _size_rotation_handler.mouse_release()
 	
 	return false
+
+var _select_mode_button : Button = null
+func _select_mode_button_selected() -> bool:
+	if _is_select_mode_button_invalid(_select_mode_button):
+		_get_select_mode_button()
+		if _is_select_mode_button_invalid(_select_mode_button):
+			return true
+
+	return _select_mode_button.button_pressed
+
+func _is_select_mode_button_invalid(button : Button) -> bool:
+	return button == null or not is_instance_valid(button) or not button.toggle_mode or button.icon == null
+
+func _get_select_mode_button() -> void:
+	var main_screen := EditorInterface.get_editor_main_screen()
+
+	var found_node : Node = main_screen.get_node_or_null("@CanvasItemEditor@9465/@MarginContainer@9280/@HFlowContainer@9281/@HBoxContainer@9282/@Button@9329")
+	if found_node != null and found_node is Button:
+		_select_mode_button = found_node
+		return
+	
+	found_node = main_screen
+	for i in 5:
+		if found_node == null:
+			break
+		found_node = found_node.get_child(0)
+
+	if found_node != null and found_node is Button:
+		_select_mode_button = found_node
+		return
+	
+	printerr("cannot find select button")

--- a/addons/complex_shape_creation/plugin.gd
+++ b/addons/complex_shape_creation/plugin.gd
@@ -1,2 +1,63 @@
 @tool
 extends EditorPlugin
+
+func _handles(object : Object) -> bool:
+	return _is_handled_node(object)
+
+func _is_handled_node(object : Object) -> bool:
+	return (
+		object is SimplePolygon2D or
+		object is RegularPolygon2D or
+		object is RegularCollisionPolygon2D or
+		object is StarPolygon2D
+	)
+
+func _edit(object : Object) -> void:
+	var parent := _size_rotation_handler.get_parent()
+	if object == null:
+		if parent != null:
+			parent.remove_child(_size_rotation_handler)
+		return
+
+	if not is_same(object, parent):
+		if parent != null:
+			parent.remove_child(_size_rotation_handler)
+		_size_rotation_handler.request_ready()
+		object.add_child(_size_rotation_handler, false, INTERNAL_MODE_FRONT)
+
+const BaseHandler := preload("res://addons/complex_shape_creation/gui_handlers/base_handler.gd")
+const SizeRotationHandler := preload("res://addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd")
+var _size_rotation_handler : SizeRotationHandler
+func _make_visible(visible) -> void:
+	if visible:
+		_size_rotation_handler = SizeRotationHandler.new(self, get_undo_redo())
+	else:
+		_remove(_size_rotation_handler)
+
+func _remove(node : Node) -> void:
+	var parent := node.get_parent()
+	if parent != null:
+		parent.remove_child(node)
+	node.queue_free()
+
+func _forward_canvas_gui_input(event) -> bool:
+	if event is InputEventMouseButton:
+		if event.button_index != MOUSE_BUTTON_MASK_LEFT:
+			return false
+		
+		if event.pressed:
+			var viewport := EditorInterface.get_editor_viewport_2d()
+			var transform := viewport.get_final_transform()
+			var size := viewport.size
+			var lower_bound := -transform.get_origin()
+			lower_bound = Vector2(lower_bound.x / transform.get_scale().x, lower_bound.y / transform.get_scale().y)
+			var upper_bound := lower_bound + Vector2(size.x / transform.get_scale().x, size.y / transform.get_scale().y)
+
+			var mouse_position = viewport.get_mouse_position()
+			if (lower_bound.x <= mouse_position.x and mouse_position.x <= upper_bound.x and
+				lower_bound.y <= mouse_position.y and mouse_position.y <= upper_bound.y):
+				return _size_rotation_handler.mouse_press(mouse_position)
+		else:
+			return _size_rotation_handler.mouse_release()
+	
+	return false

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/RegularCollisionPolygon2D.cs
@@ -103,6 +103,20 @@ public class RegularCollisionPolygon2D
         get => Instance.Scale;
         set => Instance.Scale = value;
     }
+    
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransformation(float, float, bool, bool)"/>
+    /// <summary>
+    /// Transforms <see cref="CollisionShape2D.Shape"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method modifies the existing <see cref="CollisionShape2D.Shape"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="CollisionShape2D.Shape"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>Creates and wraps a <see cref="CollisionShape2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -35,8 +35,8 @@ var offset_rotation_degrees : float = 0:
 	get:
 		return rad_to_deg(offset_rotation)
 
-@export_range(-360, 360, 0.1, "or_greater", "or_less", "radians")
 ## The offset rotation of the shape, in radians.
+@export_range(-360, 360, 0.1, "or_greater", "or_less", "radians")
 var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
@@ -242,7 +242,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 
 ## The length of the inner vertices between each normal vertices to the center of the shape. If set to [code]0[/code], it is ignored.
 ## [br][br]If used, [member vertices_count] must be set to [code]1[/code] to generate lines, and circles cannot be generated.
-## It determines the length of the bottem segment of the line.
+## It determines the length of the bottom segment of the line.
 @export_range(0, 10, 0.001, "or_greater", "hide_slider")
 var inner_size : float = 0.0:
 	set(value):
@@ -551,7 +551,7 @@ static func convert_to_line_segments(points : PackedVector2Array) -> PackedVecto
 	return points
 
 ## Modifies [param segments] to form an outline of the interconnected segments with the given [param width].
-## [param join_perimeter] controls whether the function should extend (or shorten) line segments to form a propery closed shape.
+## [param join_perimeter] controls whether the function should extend (or shorten) line segments to form a properly closed shape.
 ## For disconnected segments, use [method widen_polyline].
 ## [br][br][param segments] should contain pairs of points for each segment (see [property ConcavePolygonShape2D.segments]).
 static func widen_polyline(segments : PackedVector2Array, width : float, join_perimeter : bool) -> void:
@@ -589,7 +589,7 @@ static func widen_polyline(segments : PackedVector2Array, width : float, join_pe
 	segments[original_size] = segments[original_size - 1]
 	segments[original_size + 1] = segments[original_size + 2]
 
-## modifies [param segements] to to form the outlines of every disconnected segment with the given [param width].
+## modifies [param segments] to to form the outlines of every disconnected segment with the given [param width].
 ## For interconnected segments, use [method widen_polyline].
 ## [br][br][param segments] should contain pairs of points for each segment (see [property ConcavePolygonShape2D.segments]),
 static func widen_multiline(segments : PackedVector2Array, width : float) -> void:

--- a/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -245,15 +245,11 @@ func regenerate() -> void:
 		else:	
 			points = RegularPolygon2D.get_shape_vertices(vertices_count, size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
 		
-		if uses_width and uses_drawn_arc:
-			RegularPolygon2D.add_hole_to_points(points, 1 - width / size, false)
+		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, not uses_drawn_arc)
 
-		if uses_rounded_corners:
-			RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count)
-
-		if uses_width and not uses_drawn_arc:
-			RegularPolygon2D.add_hole_to_points(points, 1 - width / size, true)
-		
+		if not is_zero_approx(corner_size):
+			RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count, uses_width and not uses_drawn_arc)
+	
 		var segments := PackedVector2Array()
 		var original_size := points.size()
 		var modified_size := original_size

--- a/addons/complex_shape_creation/regular_geometry.gd
+++ b/addons/complex_shape_creation/regular_geometry.gd
@@ -1,0 +1,125 @@
+extends Object
+class_name RegularGeometry2D
+
+## Holds methods for creating and modifying shapes.
+
+func _init():
+	printerr("This class is meant to be a singleton, and cannot be instantiated")
+	self.free()
+
+## Modifies [param points] so that the shape it represents have rounded corners. The method uses quadratic Bézier curves for the corners.
+## [br][br][param corner_size] determines how long each corner is, from the original point to at most half the side length.
+## [param corner_smoothness] determines how many [b]lines[/b] are in each corner.
+## [br][br][param start_index] & [param length] can be used to specify only part of the shape should be rounded.
+## [param limit_ending_slopes] determines whether the ending corners should still be limited to half the side length. Does not work if the entire shape is being rounded.
+## [param original_array_size], when used, indicates that the array has already been resized, so the method should add points into the empty space.
+## This parameter specifies the part of the array that is currently used.
+static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
+	start_index := 0, length := -1, limit_ending_slopes := true, original_array_size := 0) -> void:
+	# argument prep 
+	var corner_size_squared := corner_size ** 2
+	var points_per_corner := corner_smoothness + 1
+	var resize_array := false
+	if original_array_size <= 0:
+		resize_array = true
+		original_array_size = points.size()
+	if length < 0:
+		length = original_array_size - start_index
+	if corner_smoothness == 0:
+		corner_smoothness = 32 / points.size()
+	
+	assert(points.size() >= 3, "param 'points' must have at least 3 points.")
+	assert(corner_size >= 0, "param 'corner_size' must be 0 or greater.")
+	assert(corner_smoothness >= 0, "param 'corner_smoothness' must be 0 or greater.")
+	assert(start_index >= 0, "param 'start_index' must be 0 or greater.")
+	assert(start_index + length <= original_array_size, "sum of param 'start_index' & param 'length' must not be greater than the original size of the array (param 'original_array_size', or if 0, size of param 'points').")
+	assert(limit_ending_slopes || length != original_array_size, "param 'limit_ending_slopes' was set to false, but the entire shape is being rounded so there are no \"ending\" slopes.")
+
+	# resizing and spacing
+	var size_increase := SizeIncrease.add_rounded_corners(length, corner_smoothness)
+	if resize_array:
+		points.resize(original_array_size + size_increase)
+		for i in (original_array_size - start_index - length):
+			points[-i - 1] = points[-i - 1 - size_increase]
+	else:
+		assert(original_array_size + size_increase <= points.size(), "The function is set to use the empty space in param 'points' but it is too small.")
+		for i in (original_array_size - start_index - length):
+			points[original_array_size - i - 1 + size_increase]= points[original_array_size - i - 1]
+
+	for i in length:
+		var index := length - i - 1
+		points[start_index + index * points_per_corner] = points[index + start_index]
+
+	# pre-loop prep and looping
+	var current_point := points[start_index]
+	var next_point : Vector2
+	var point_after_final : Vector2
+	var previous_point : Vector2
+	if start_index == 0:
+		if length == original_array_size:
+			previous_point = points[original_array_size + size_increase - points_per_corner]
+		else:
+			previous_point = points[original_array_size + size_increase - 1]
+	else:
+		previous_point = points[start_index - 1]
+
+	if start_index + length == original_array_size:
+		point_after_final = points[0]
+	else:
+		point_after_final = points[start_index + length * points_per_corner - points.size()]
+	
+	for i in length:
+		if i + 1 == length:
+			next_point = point_after_final
+		else:
+			next_point = points[start_index + (i + 1) * points_per_corner]
+		
+		# creating corner
+		var starting_slope := (current_point - previous_point)
+		var ending_slope := (current_point - next_point)
+		var starting_point : Vector2
+		var ending_point : Vector2
+
+		var slope_limit_value := 1 if not limit_ending_slopes and i == 0 else 2
+		if starting_slope.length_squared() / (slope_limit_value * slope_limit_value) < corner_size_squared:
+			starting_point = current_point - starting_slope / (slope_limit_value + 0.001)
+		else:
+			starting_point = current_point - starting_slope.normalized() * corner_size
+		
+		slope_limit_value = 1 if not limit_ending_slopes and i + 1 == length else 2
+		if ending_slope.length_squared() / (slope_limit_value * slope_limit_value) < corner_size_squared:
+			ending_point = current_point - ending_slope / (slope_limit_value + 0.001)
+		else:
+			ending_point = current_point - ending_slope.normalized() * corner_size
+
+		points[start_index + i * points_per_corner] = starting_point
+		points[start_index + i * points_per_corner + points_per_corner - 1] = ending_point
+		# sub_i is initialized with a value of 1 as a corner_smoothness of 1 has no in-between points.
+		var sub_i := 1
+		while sub_i < corner_smoothness:
+			var t_value := sub_i / (corner_smoothness as float)
+			points[start_index + i * points_per_corner + sub_i] = _quadratic_bezier_interpolate(starting_point, current_point, ending_point, t_value)
+			sub_i += 1
+		
+		# end, prep for next loop.
+		previous_point = current_point
+		current_point = next_point
+
+static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
+	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
+
+## sub class that designates how much each method expands the array.
+class SizeIncrease:
+	extends Object
+
+	func _init():
+		printerr("This class is meant to be a singleton, and cannot be instantiated")
+		self.free()
+
+	## Designates how much [method RegularGeometry2D.add_rounded_corners] expands the array.
+	## [br][br][param length] specifies many points are to be converted into rounded corners.
+	## [param corner_smoothness] specifies how many lines are in each corner.
+	static func add_rounded_corners(length : int, corner_smoothness : int) -> int:
+		assert(length >= 0, "param 'length' must be positive.")
+		assert(corner_smoothness > 0, "param 'corner_smoothness' must be positive.")
+		return length * (corner_smoothness + 1) - length

--- a/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
@@ -143,6 +143,20 @@ public class RegularPolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <inheritdoc cref="SimplePolygon2D.ApplyTransformation(float, float)"/>
+    /// <summary>
+    /// Transforms <see cref="Polygon2D.Polygon"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method modifies the existing <see cref="Polygon2D.Polygon"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="Polygon2D.Polygon"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
+
     /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.

--- a/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/complex_shape_creation/regular_polygon_2d/RegularPolygon2D.cs
@@ -158,10 +158,23 @@ public class RegularPolygon2D
     public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
 
     /// <summary>
+    /// Queues <see cref="Regenerate"/> for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+    /// </summary>
+    /// <remarks>
+    /// If this method is called when the node is outside the <see cref="SceneTree"/>, regeneration will be delayed to when the node enters the tree. 
+    /// Use <see cref="Regenerate"/> directly to force initialization.
+    /// </remarks>
+    public void QueueRegenerate() => Instance.Call(MethodName.QueueRegenerate);
+
+    /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.
     /// </summary>
+    public void Regenerate() => Instance.Call(MethodName.Regenerate);
+
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public void RegeneratePolygon() => Instance.Call(MethodName.RegeneratePolygon);
+
     /// <summary>
     /// Checks whether the current properties of this node will have it use <see cref="Polygon2D.Polygon">.
     /// </summary>

--- a/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -325,6 +325,11 @@ func _init(vertices_count : int = 1, size := 10.0, offset_rotation := 0.0, color
 	if corner_smoothness != 0:
 		self.corner_smoothness = corner_smoothness
 	
+# func _ready() -> void:
+# 	if Engine.is_editor_hint():
+# 		var control := preload("res://addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd").new(self, 2)
+# 		add_child(control)
+
 func _get_configuration_warnings() -> PackedStringArray:
 	if drawn_arc == 0:
 		return ["nothing will be drawn when 'drawn_arc' is 0."]

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -92,6 +92,9 @@ public partial class SimplePolygon2D
     public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
     public void ApplyTransformation(float rotation, float scale) => Instance.Call(MethodName.ApplyTransformation, rotation, scale);
 
+    /// <inheritdoc cref="CanvasItem.QueueRedraw"/>
+    public void QueueRedraw() => Instance.QueueRedraw();
+
     /// <summary>Creates and wraps a <see cref="SimplePolygon2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>
     /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -83,6 +83,15 @@ public partial class SimplePolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <summary>
+    /// Transforms <see cref="SimplePolygon2D"/>, rotating it by <paramref name="rotation"/> radians and scaling it by a factor of <paramref name="scale"/>.
+    /// </summary>
+    /// <remarks>Unlike other methods, this simply affects <see cref="OffsetRotation"/> and <see cref="Size"/>, regenerating the shape </remarks>
+    /// <param name="rotation">The amount to rotate the shape in radians.</param>
+    /// <param name="scale">The factor to scale the shape.</param>
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
+    public void ApplyTransformation(float rotation, float scale) => Instance.Call(MethodName.ApplyTransformation, rotation, scale);
+
     /// <summary>Creates and wraps a <see cref="SimplePolygon2D"/> around <paramref name="instance"/>.</summary>
     /// <param name="instance">The instance of <see cref="GDScriptEquivalent"/> to wrap.</param>
     /// <exception cref="ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>

--- a/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
+++ b/addons/complex_shape_creation/simple_polygon_2d/SimplePolygon2D.cs
@@ -52,11 +52,17 @@ public partial class SimplePolygon2D
         get => (Color)Instance.Get(PropertyName.Color);
         set => Instance.Set(PropertyName.Color, value);
     }
-    /// <summary>The offset position of the shape.</summary>
+    [Obsolete("Property name has been replaced, use 'Offset' instead.", false)]
     public Vector2 OffsetPosition
     {
         get => (Vector2)Instance.Get(PropertyName.OffsetPosition);
         set => Instance.Set(PropertyName.OffsetPosition, value);
+    }
+    /// <summary>The offset position of the shape.</summary>
+    public Vector2 Offset
+    {
+        get => (Vector2)Instance.Get(PropertyName.Offset);
+        set => Instance.Set(PropertyName.Offset, value);
     }
     /// <summary>Position, relative to the node's parent.</summary>
     public Vector2 Position

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -108,6 +108,11 @@ func _init(vertices_count : int = 1, size := 10.0, offset_rotation := 0.0, color
 	if offset_position != Vector2.ZERO:
 		self.offset = offset_position
 
+# func _ready() -> void:
+# 	if Engine.is_editor_hint():
+# 		var control := preload("res://addons/complex_shape_creation/gui_handlers/size_rotation_handler.gd").new(self)
+# 		add_child(control)
+
 static var _circle := get_shape_vertices(32)
 
 ## Returns a [PackedVector2Array] with the points for the shape with the specified [param vertices_count].

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -52,11 +52,19 @@ var color : Color = Color.WHITE:
 		color = value
 		queue_redraw()
 
-## The offset position of the shape.
+## see [member offset]
+## @deprecated
 @export
-var offset_position : Vector2 = Vector2.ZERO:
+var offset_position := Vector2.ZERO:
 	set(value):
-		offset_position = value
+		offset = value
+	get:
+		return offset
+
+## The offset position of the shape.
+var offset : Vector2 = Vector2.ZERO:
+	set(value):
+		offset = value
 		queue_redraw()
 
 ## A method for consistency across other nodes. [b]Equivalent to [method CanvasItem.queue_redraw].[/b]
@@ -69,24 +77,24 @@ func regenerate() -> void:
 
 func _draw() -> void:
 	if (vertices_count == 1):
-		draw_circle(offset_position, size, color)
+		draw_circle(offset, size, color)
 		return
 	
 	if (vertices_count == 2):
 		if offset_rotation == 0:
-			draw_line(Vector2.UP * size + offset_position, Vector2.DOWN * size + offset_position, color)
+			draw_line(Vector2.UP * size + offset, Vector2.DOWN * size + offset, color)
 			return
 		
 		var point1 := Vector2(sin(offset_rotation), -cos(offset_rotation)) * size
-		draw_line(point1 + offset_position, -point1 + offset_position, color)
+		draw_line(point1 + offset, -point1 + offset, color)
 		return
 	
 	if (vertices_count == 4 && offset_rotation == 0):
 		const sqrt_two_over_two := 0.707106781
-		draw_rect(Rect2(offset_position - Vector2.ONE * sqrt_two_over_two * size, Vector2.ONE * sqrt_two_over_two * size * 2), color)
+		draw_rect(Rect2(offset - Vector2.ONE * sqrt_two_over_two * size, Vector2.ONE * sqrt_two_over_two * size * 2), color)
 		return
 		
-	draw_colored_polygon(get_shape_vertices(vertices_count, size, offset_rotation, offset_position), color)
+	draw_colored_polygon(get_shape_vertices(vertices_count, size, offset_rotation, offset), color)
 
 func _init(vertices_count : int = 1, size := 10.0, offset_rotation := 0.0, color := Color.WHITE, offset_position := Vector2.ZERO):
 	if vertices_count != 1:
@@ -98,7 +106,7 @@ func _init(vertices_count : int = 1, size := 10.0, offset_rotation := 0.0, color
 	if color != Color.WHITE:
 		self.color = color
 	if offset_position != Vector2.ZERO:
-		self.offset_position = offset_position
+		self.offset = offset_position
 
 static var _circle := get_shape_vertices(32)
 

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -122,9 +122,7 @@ static func get_shape_vertices(vertices_count : int, size : float = 1, offset_ro
 	assert(size > 0, "param 'size' must be positive.")
 	
 	if vertices_count == 1:
-		if size == 1 and offset_rotation == 0.0 and offset_position == Vector2.ZERO:
-			return PackedVector2Array(_circle)
-		return PackedVector2Array(_circle) * Transform2D(offset_rotation, Vector2.ONE * size, 0, offset_position)
+		return _circle * Transform2D(-offset_rotation, Vector2.ONE * size, 0, offset_position)
 
 	var points := PackedVector2Array()
 	points.resize(vertices_count)

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -59,6 +59,14 @@ var offset_position : Vector2 = Vector2.ZERO:
 		offset_position = value
 		queue_redraw()
 
+## A method for consistency across other nodes. [b]Equivalent to [method CanvasItem.queue_redraw].[/b]
+func queue_regenerate() -> void:
+	queue_redraw()
+
+## A method for consistency across other nodes, and does not even regenerate the shape immediately. [b]Equivalent to [method CanvasItem.queue_redraw].[/b]
+func regenerate() -> void:
+	queue_redraw()
+
 func _draw() -> void:
 	if (vertices_count == 1):
 		draw_circle(offset_position, size, color)

--- a/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
+++ b/addons/complex_shape_creation/simple_polygon_2d/simple_polygon_2d.gd
@@ -39,6 +39,12 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		queue_redraw()
 
+## Transforms [member CollisionShape2D.shape], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+func apply_transformation(rotation : float, scale : float) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	offset_rotation += rotation
+	size *= scale
+
 ## The color of the shape.
 @export
 var color : Color = Color.WHITE:

--- a/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
+++ b/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
@@ -129,6 +129,17 @@ public class StarPolygon2D
         set => Instance.Scale = value;
     }
 
+    /// <inheritdoc cref="RegularPolygon2D.ApplyTransformation(float, float, bool, bool)"/>
+    /// <remarks>
+    /// This method modifies the existing <see cref="Polygon2D.Polygon"/>, so is generally faster than changing <see cref="Size"/> and <see cref="OffsetRotation"/>.
+    /// This only happens if the transformed shape is congruent to the original. If it is not or <see cref="Polygon2D.Polygon"/> isn't used, the shape is regenerated.
+    /// <br/><br/><b>Warning</b>: Currently method does not check if the <see cref="CornerSize"/> value is clamped due to small side lengths.
+    /// If this occurs in the original or transformed shape and <paramref name="scale_corner_size"/> is <see langword="false"/>, the shape will not be accurate to this node's properties.
+    /// </remarks>
+    /// <param name="scale_width">Toggles scaling <see cref="Width"/>, applying correction if <see langword="false"/>.</param>
+    /// <param name="scale_corner_size">Toggles scaling <see cref="CornerSize"/>, applying correction if <see langword="false"/>.</param>
+    public void ApplyTransformation(float rotation, float scale, bool scale_width = true, bool scale_corner_size = true) => Instance.Call(MethodName.ApplyTransformation, rotation, scale, scale_width, scale_corner_size);
+
     /// <summary>
     /// Sets <see cref="innerSize"/> such that the angle formed by each point is equivalent to <paramref name="angle"/>, in radians.
     /// </summary>

--- a/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
+++ b/addons/complex_shape_creation/star_polygon_2d/StarPolygon2D.cs
@@ -24,6 +24,12 @@ public class StarPolygon2D
     /// The number of points the star has.
     /// </summary>
     /// <remarks>If set to <c>1</c>, a line is drawn.</remarks>
+    public int VerticesCount
+    {
+        get => (int)Instance.Get(PropertyName.VerticesCount);
+        set => Instance.Set(PropertyName.VerticesCount, value);
+    }
+    [Obsolete("Property name has been replaced, use 'VerticesCount' instead.", false)]
     public int PointCount
     {
         get => (int)Instance.Get(PropertyName.PointCount);
@@ -144,11 +150,25 @@ public class StarPolygon2D
     /// Sets <see cref="innerSize"/> such that the angle formed by each point is equivalent to <paramref name="angle"/>, in radians.
     /// </summary>
     public void SetPointAngle(float angle) => Instance.Call(MethodName.SetPointAngle, angle);
+
+    /// <summary>
+    /// Queues <see cref="Regenerate"/> for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+    /// </summary>
+    /// <remarks>
+    /// If this method is called when the node is outside the <see cref="SceneTree"/>, regeneration will be delayed to when the node enters the tree. 
+    /// Use <see cref="Regenerate"/> directly to force initialization.
+    /// </remarks>
+    public void QueueRegenerate() => Instance.Call(MethodName.QueueRegenerate);
+
     /// <summary>
     /// Sets <see cref="Polygon2D.Polygon"> using the properties of this node. 
     /// This method can be used when the node is outside the <see cref="SceneTree"/> to force this, and ignores the result of <see cref="UsesPolygonMember"/>.
     /// </summary>
+    public void Regenerate() => Instance.Call(MethodName.Regenerate);
+
+    [Obsolete("Method name has changed, use 'Regenerate' instead.", false)]
     public void RegeneratePolygon() => Instance.Call(MethodName.RegeneratePolygon);
+
     /// <summary>
     /// Checks whether the current properties of this node will have it use <see cref="Polygon2D.Polygon">.
     /// </summary>

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -8,19 +8,27 @@ class_name StarPolygon2D
 ## A node that draws star, with complex properties.
 ## It uses [method CanvasItem.draw_colored_polygon], [method CanvasItem.draw_polyline], or [member Polygon2D.polygon]
 ## [br][br][b]Note[/b]: If the node is set to use [member Polygon2D.polygon] when it is outside the [SceneTree],
-## regeneration will be delayed to when it enters it. Use [method regenerate_polygon] to force regeneration.
+## regeneration will be delayed to when it enters it. Use [method regenerate] to force regeneration.
 
 ## The number of points the star has.
 ## [br][br]If set to [code]1[/code], a line is drawn.
+var vertices_count : int = 5:
+	set(value):
+		assert(value > 0, "property 'vertices_count' must be greater than 0")
+		vertices_count = value
+		if vertices_count == 1 and width > 0:
+			polygon = PackedVector2Array()
+			return
+		queue_regenerate()
+
+## see [member vertices_count]
+## @deprecated
 @export_range(1, 2000)
 var point_count : int = 5:
 	set(value):
-		assert(value > 0, "property 'point_count' must be greater than 0")
-		point_count = value
-		if point_count == 1 and width > 0:
-			polygon = PackedVector2Array()
-			return
-		_pre_redraw()
+		vertices_count = value
+	get:
+		return vertices_count
 		
 ## The length of each point to the center of the star.
 ## [br][br]For lines, it determines the length of the top part.
@@ -29,7 +37,7 @@ var size : float = 10.0:
 	set(value):
 		assert(value > 0, "property 'size' must be greater than 0");
 		size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The length of the inner vertices to the center of the star.
 ## [br][br]For lines, it determines the length of the bottom part.
@@ -38,7 +46,7 @@ var inner_size : float = 5.0:
 	set(value):
 		assert(value > 0, "property 'inner_size' must be greater than 0");
 		inner_size = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The offset rotation of the star, in degrees.
 var offset_rotation_degrees : float = 0:
@@ -52,7 +60,7 @@ var offset_rotation_degrees : float = 0:
 var offset_rotation : float = 0:
 	set(value):
 		offset_rotation = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
 ## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
@@ -83,12 +91,12 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	if not scale_width and \
 		(width >= size and width < size / scale
 		or width < size and width >= size / scale):
-		regenerate_polygon()
+		regenerate()
 		return
 	
 	var points_per_corner := 0
 	if corner_size > 0:
-		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / point_count 
+		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / vertices_count 
 	points_per_corner += 1
 	
 	var shape := polygon
@@ -114,7 +122,7 @@ var width : float = -0.001:
 			return
 
 		width = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## The arc of the drawn star, in degrees, cutting off beyond that arc. 
 ## Values greater than [code]360[/code] or [code]-360[/code] draws a full star. It starts at the top point.
@@ -138,7 +146,7 @@ var drawn_arc_degrees : float = 360:
 var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
-		_pre_redraw()
+		queue_regenerate()
 		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
@@ -150,22 +158,22 @@ var corner_size : float = 0.0:
 	set(value):
 		assert(value >= 0, "property 'corner_size' must be greater than or equal to 0")
 		corner_size = value
-		_pre_redraw()
+		queue_regenerate()
 
-## How many lines make up each corner. A value of [code]0[/code] will use a value of [code]32[/code] divided by [member point_count].
+## How many lines make up each corner. A value of [code]0[/code] will use a value of [code]32[/code] divided by [member vertices_count].
 ## This only has an effect if [member corner_size] is used.
 @export_range(0, 8, 1, "or_greater") 
 var corner_smoothness : int = 0:
 	set(value):
 		assert(value >= 0, "property 'corner_smoothness' must be greater than or equal to 0")
 		corner_smoothness = value
-		_pre_redraw()
+		queue_regenerate()
 
 ## Sets [member inner_size] such that the angle formed by each point is equivalent to [param angle], in radians.
 func set_point_angle(angle : float) -> void:
 	assert(0 < angle and angle < TAU, "param 'angle' must be between 0 and TAU")
 	angle /= 2
-	inner_size = size * sin(angle / (sin(PI - angle - TAU / point_count / 2)))
+	inner_size = size * sin(angle / (sin(PI - angle - TAU / vertices_count / 2)))
 
 # "_BLOCK_QUEUE" is used by _init to prevent regeneration of the shape when it is already set by PackedScene.instantiate().
 const _NOT_QUEUED = 0
@@ -174,7 +182,14 @@ const _BLOCK_QUEUE = 2
 
 var _queue_status : int = _NOT_QUEUED 
 
+## @deprecated
 func _pre_redraw() -> void:
+	queue_regenerate()
+
+## Queues [method regenerate] for the next process frame. If this method is called multiple times, the shape is only regenerated once.
+## [br][br]If this method is called when the node is outside the [SceneTree], regeneration will be delayed to when the node enters the tree.
+## Call [method regenerate] directly to force initialization.
+func queue_regenerate() -> void:
 	if not uses_polygon_member():
 		# the setting the 'polygon' property already calls queue_redraw
 		queue_redraw()
@@ -192,18 +207,18 @@ func _pre_redraw() -> void:
 	_queue_status = _NOT_QUEUED
 	if not uses_polygon_member():
 		return
-	regenerate_polygon()
+	regenerate()
 
 func _enter_tree() -> void:
 	if _queue_status == _IS_QUEUED and uses_polygon_member():
-		regenerate_polygon()
+		regenerate()
 	_queue_status = _NOT_QUEUED
 
 func _draw():
 	if uses_polygon_member() or drawn_arc == 0:
 		return
 	
-	if point_count == 1:
+	if vertices_count == 1:
 		var point := -_get_vertices(offset_rotation + drawn_arc, size)
 		var width_value = width if width != 0 else -1
 		if drawn_arc <= -TAU or drawn_arc >= TAU:
@@ -232,10 +247,10 @@ func _draw():
 		draw_polyline(line, color, width_value, antialiased)
 		return
 	
-	var points := get_star_vertices(point_count, size, inner_size, offset_rotation, offset, drawn_arc)
+	var points := get_star_vertices(vertices_count, size, inner_size, offset_rotation, offset, drawn_arc)
 
 	if not is_zero_approx(corner_size):
-		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count)
+		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count)
 
 	if is_zero_approx(width):
 		points.append(points[0])
@@ -262,9 +277,14 @@ func _draw():
 		return
 	draw_colored_polygon(points, color);
 	
+## see [method regenerate].
+## @deprecated
+func regenerate_polygon() -> void:
+	regenerate()
+
 ## Sets [member Polygon2D.polygon] using the properties of this node. 
 ## This method can be used when the node is outside the [SceneTree] to force this, and ignores the result of [method uses_polygon_member].
-func regenerate_polygon():
+func regenerate() -> void:
 	_queue_status = _NOT_QUEUED
 	if drawn_arc == 0:
 		polygon = PackedVector2Array()
@@ -272,12 +292,12 @@ func regenerate_polygon():
 	
 	var uses_width := width < size
 	var uses_drawn_arc := -TAU < drawn_arc and drawn_arc < TAU
-	var points = StarPolygon2D.get_star_vertices(point_count, size, inner_size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
+	var points = StarPolygon2D.get_star_vertices(vertices_count, size, inner_size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
 	if uses_width:
 		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, not uses_drawn_arc)
 
 	if not is_zero_approx(corner_size):
-		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count, uses_width and not uses_drawn_arc)
+		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count, uses_width and not uses_drawn_arc)
 	
 	polygon = points
 	
@@ -287,7 +307,7 @@ func _init(vertices_count : int = 1, size := 10.0, inner_size := 5.0, offset_rot
 		_queue_status = _BLOCK_QUEUE
 
 	if vertices_count != 1:
-		self.point_count = vertices_count
+		self.vertices_count = vertices_count
 	if size != 10.0:
 		self.size = size
 	if inner_size != 5.0:
@@ -316,16 +336,16 @@ func _get_configuration_warnings() -> PackedStringArray:
 func uses_polygon_member() -> bool:
 	return (
 		width > 0
-		and point_count != 1
+		and vertices_count != 1
 	)
 
 ## Returns a [PackedVector2Array] with points for forming the specified star.
 ## [br][br][param add_central_point] adds [param offset_rotation] at the end of the array. 
 ## It only has an effect if [param drawn_arc] is used and isn't ±[constant @GDSCript.PI].
 ## It should be set to false when using [method RegularPolygon2D.add_hole_to_points].
-static func get_star_vertices(point_count : int, size : float, inner_size : float, offset_rotation := 0.0, offset_position := Vector2.ZERO,
+static func get_star_vertices(vertices_count : int, size : float, inner_size : float, offset_rotation := 0.0, offset_position := Vector2.ZERO,
 	drawn_arc := TAU, add_central_point := true) -> PackedVector2Array:
-	assert(point_count > 1, "param 'point_count' must be greater than 1")
+	assert(vertices_count > 1, "param 'vertices_count' must be greater than 1")
 	assert(size > 0, "param 'size' must be greater than 0")
 	assert(inner_size > 0, "param 'inner_size' must be greater than 0")
 	assert(drawn_arc != 0, "param 'drawn_arc' cannot be 0")
@@ -333,10 +353,10 @@ static func get_star_vertices(point_count : int, size : float, inner_size : floa
 	var points := PackedVector2Array()
 	offset_rotation += PI
 	if drawn_arc >= TAU or drawn_arc <= -TAU:
-		points.resize(point_count * 2)
+		points.resize(vertices_count * 2)
 		var current_rotation := offset_rotation
-		var rotation_spacing := TAU / point_count / 2
-		for i in point_count:	
+		var rotation_spacing := TAU / vertices_count / 2
+		for i in vertices_count:	
 			points[i * 2] = Vector2(-sin(current_rotation), cos(current_rotation)) * size + offset_position
 			current_rotation += rotation_spacing
 			points[i * 2 + 1] = Vector2(-sin(current_rotation), cos(current_rotation)) * inner_size + offset_position
@@ -344,7 +364,7 @@ static func get_star_vertices(point_count : int, size : float, inner_size : floa
 		return points
 	
 	var sign := signf(drawn_arc)
-	var rotation_spacing := TAU / point_count * sign
+	var rotation_spacing := TAU / vertices_count * sign
 	var half_rotation_spacing := rotation_spacing / 2
 	var original_vertices_count := floori(drawn_arc / half_rotation_spacing)
 	var ends_on_vertex := is_equal_approx(drawn_arc, original_vertices_count * half_rotation_spacing)

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -232,14 +232,11 @@ func regenerate_polygon():
 	var uses_width := width < size
 	var uses_drawn_arc := -TAU < drawn_arc and drawn_arc < TAU
 	var points = StarPolygon2D.get_star_vertices(point_count, size, inner_size, offset_rotation, Vector2.ZERO, drawn_arc, not uses_width)
-	if uses_width and uses_drawn_arc:
-		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, false)
+	if uses_width:
+		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, not uses_drawn_arc)
 
 	if not is_zero_approx(corner_size):
-		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count)
-
-	if uses_width and not uses_drawn_arc:
-		RegularPolygon2D.add_hole_to_points(points, 1 - width / size, true)
+		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / point_count, uses_width and not uses_drawn_arc)
 	
 	polygon = points
 	

--- a/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -54,6 +54,47 @@ var offset_rotation : float = 0:
 		offset_rotation = value
 		_pre_redraw()
 
+## Transforms [member Polygon2D.polygon], rotating it by [param rotation] radians and scaling it by a factor of [param scaler].
+## This method modifies the existing [member Polygon2D.polygon], so is generally faster than changing [member size]/[member inner_size] and [member offset_rotation].
+## This only happens if the transformed shape is congruent to the original. If it is not or [member Polygon2D.polygon] isn't used, the shape is regenerated.
+## [br][br][param scale_width] toggles scaling [member width].
+## [param scale_corner_size] toggles scaling [member corner_size].
+## If these values are [code]false[/code], their respective properties are not altered and the shape is corrected.
+## [br][br][b][color=red]Warning[/color][/b]: Currently method does not check if the [member corner_size] value is clamped due to small side lengths.
+## If this occurs in the original or transformed shape and [param scale_corner_size] is [code]false[/code], the shape will not be accurate to this node's properties.
+func apply_transformation(rotation : float, scale : float, scale_width := true, scale_corner_size := true) -> void:
+	assert(scale > 0, "param 'scale' should be positive.")
+	_queue_status = _BLOCK_QUEUE
+	offset_rotation += rotation
+	size *= scale
+	inner_size *= scale
+	if scale_width:
+		width *= scale
+
+	if scale_corner_size:
+		corner_size *= scale
+
+	_queue_status = _NOT_QUEUED
+	
+	if not uses_polygon_member():
+		queue_redraw()
+		return
+
+	if not scale_width and \
+		(width >= size and width < size / scale
+		or width < size and width >= size / scale):
+		regenerate_polygon()
+		return
+	
+	var points_per_corner := 0
+	if corner_size > 0:
+		points_per_corner = corner_smoothness if corner_smoothness != 0 else corner_smoothness / point_count 
+	points_per_corner += 1
+	
+	var shape := polygon
+	RegularGeometry2D.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
+	polygon = shape
+
 @export_group("complex")
 
 # The default value is -0.001 so that dragging it into positive values is quick.

--- a/tests/c#_interop/RegularCollisionPolygon2DTests.cs
+++ b/tests/c#_interop/RegularCollisionPolygon2DTests.cs
@@ -129,4 +129,22 @@ public class RegularCollisionPolygon2DTests : TestClass
 
         result.Length.ShouldBe(16);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularCollisionPolygon2D expected = new(4, 10, 0, 0, Mathf.Tau, 1, 1);
+        RegularCollisionPolygon2D sample = new(4, 10, 0, 0, Mathf.Tau, 1, 1);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.Regenerate();
+        sample.Regenerate();
+
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -97,11 +97,24 @@ public class RegularPolygon2DTests : TestClass
     }
 
     [Test]
-    public void RegeneratePolygon_PolygonSetEmpty_PolygonFilled()
+    public async System.Threading.Tasks.Task QueueRegenerate_PolygonSetEmpty_PolygonFilled()
+    {
+        TestScene.AddChild(polygon);
+        polygon.Instance.Polygon = System.Array.Empty<Vector2>();
+
+        polygon.QueueRegenerate();
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+
+        polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public void Regenerate_PolygonSetEmpty_PolygonFilled()
     {
         polygon.Instance.Polygon = System.Array.Empty<Vector2>();
 
-        polygon.RegeneratePolygon();
+        polygon.Regenerate();
 
         polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
     }
@@ -146,12 +159,12 @@ public class RegularPolygon2DTests : TestClass
     {
         const float rotationAmount = 1.2f;
         const float sizeScale = 2;
-        RegularPolygon2D expected = new(4, 10, 0);
-        RegularPolygon2D sample = new(4, 10, 0);
+        RegularPolygon2D expected = new(4, width: 100);
+        RegularPolygon2D sample = new(4, width: 100);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
-        expected.RegeneratePolygon();
-        sample.RegeneratePolygon();
+        expected.Regenerate();
+        sample.Regenerate();
 
         sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 

--- a/tests/c#_interop/RegularPolygon2DTests.cs
+++ b/tests/c#_interop/RegularPolygon2DTests.cs
@@ -140,4 +140,22 @@ public class RegularPolygon2DTests : TestClass
 
         result.ShouldNotBeEmpty();
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/SimplePolygon2DTests.cs
+++ b/tests/c#_interop/SimplePolygon2DTests.cs
@@ -70,4 +70,22 @@ public class SimplePolygon2DTests : TestClass
 
         array.Length.ShouldBe(4);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -16,11 +16,11 @@ public class StarPolygon2DTests : TestClass
     }
 
     [Test]
-    public void PointCount_Set3_Returns3()
+    public void VerticesCount_Set3_Returns3()
     {
-        polygon.PointCount = 3;
+        polygon.VerticesCount = 3;
         
-        polygon.PointCount.ShouldBe(3);
+        polygon.VerticesCount.ShouldBe(3);
     }
 
     [Test]
@@ -113,13 +113,26 @@ public class StarPolygon2DTests : TestClass
 
         result.ShouldBe(true);
     }
+    
+    [Test]
+    public async System.Threading.Tasks.Task QueueRegenerate_PolygonSetEmpty_PolygonFilled()
+    {
+        TestScene.AddChild(polygon);
+        polygon.Instance.Polygon = System.Array.Empty<Vector2>();
+
+        polygon.QueueRegenerate();
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+        await TestScene.ToSignal(TestScene.GetTree(), SceneTree.SignalName.ProcessFrame);
+
+        polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
+    }
 
     [Test]
-    public void RegeneratePolygon_PolygonSetEmpty_PolygonFilled()
+    public void Regenerate_PolygonSetEmpty_PolygonFilled()
     {
         polygon.Instance.Polygon = System.Array.Empty<Vector2>();
 
-        polygon.RegeneratePolygon();
+        polygon.Regenerate();
 
         polygon.Instance.Polygon.Length.ShouldBeGreaterThan(0);
     }
@@ -137,12 +150,12 @@ public class StarPolygon2DTests : TestClass
     {
         const float rotationAmount = 1.2f;
         const float sizeScale = 2;
-        RegularPolygon2D expected = new(4, 10, 0);
-        RegularPolygon2D sample = new(4, 10, 0);
+        StarPolygon2D expected = new(5, width: 100);
+        StarPolygon2D sample = new(5, width: 100);
         expected.OffsetRotation += rotationAmount;
         expected.Size *= sizeScale;
-        expected.RegeneratePolygon();
-        sample.RegeneratePolygon();
+        expected.Regenerate();
+        sample.Regenerate();
 
         sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
 

--- a/tests/c#_interop/StarPolygon2DTests.cs
+++ b/tests/c#_interop/StarPolygon2DTests.cs
@@ -131,4 +131,22 @@ public class StarPolygon2DTests : TestClass
 
         array.Length.ShouldBe(8);
     }
+
+    [Test]
+    public void ApplyTransform_SampleShape_ReturnsExpected()
+    {
+        const float rotationAmount = 1.2f;
+        const float sizeScale = 2;
+        RegularPolygon2D expected = new(4, 10, 0);
+        RegularPolygon2D sample = new(4, 10, 0);
+        expected.OffsetRotation += rotationAmount;
+        expected.Size *= sizeScale;
+        expected.RegeneratePolygon();
+        sample.RegeneratePolygon();
+
+        sample.ApplyTransformation(rotationAmount, sizeScale, false, false);
+
+        sample.OffsetRotation.ShouldBe(expected.OffsetRotation);
+        sample.Size.ShouldBe(expected.Size);
+    }
 }

--- a/tests/unit_tests/gut_collection_test.gd
+++ b/tests/unit_tests/gut_collection_test.gd
@@ -1,0 +1,32 @@
+extends GutTest
+class_name GutCollectionTest
+
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
+		return
+	
+	var failed_indexes := PackedInt32Array()
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			failed_indexes.append(i)
+
+	if failed_indexes.is_empty():
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+		return
+	
+	var message := "%s elements do not match at indices: %s" % [failed_indexes.size(), failed_indexes]
+	for i in failed_indexes:
+		message += "\n[%s]: %s vs %s" % [i, c1[i], c2[i]]
+	
+	_fail(message)
+
+func to_vector2s(nums : Array) -> PackedVector2Array:
+	assert(nums.size() % 2 == 0)
+	var points := PackedVector2Array()
+	@warning_ignore("integer_division") 
+	points.resize(nums.size() / 2)
+	for i in points.size():
+		points[i] = Vector2(nums[i * 2], nums[i * 2 + 1])
+	
+	return points

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -1,0 +1,122 @@
+extends GutTest
+
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s | %s)" % [c1, c2])
+		return
+	
+	var has_failed := false
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
+			has_failed = true
+
+	if not has_failed:
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+
+var various_shapes_with_corner_smoothness := [
+	[1, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],
+	[3, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],
+	[3, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2(0.75, 1), Vector2(0.75, 1)]],
+]
+func test_add_rounded_corners__various_shapes_with_0_corner_size__expected_shape(p=use_parameters(various_shapes_with_corner_smoothness)):
+	var corner_smoothness : int = p[0]
+	var shape : PackedVector2Array = p[1]
+	var original := PackedVector2Array(shape)
+	var expected_size := shape.size() * (corner_smoothness + 1)
+
+	RegularGeometry2D.add_rounded_corners(shape, 0, corner_smoothness)
+
+	assert_eq(shape.size(), expected_size, "Size of modified array should be %s but was %s" % [expected_size, shape.size()])
+	for i in original.size():
+		for i2 in (corner_smoothness + 1):
+			assert_almost_eq(shape[i * (corner_smoothness + 1) + i2], original[i], Vector2.ONE * 0.001)
+
+func test_add_rounded_corners__oversized_corner_size__corner_size_limited():
+	const sample_corner_smoothness := 2
+	const oversized_corner_size := 32.432
+	var shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	const expected_shape : PackedVector2Array = [
+		Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN,
+		Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT,
+		Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP,
+		Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT
+	]
+
+	RegularGeometry2D.add_rounded_corners(shape, oversized_corner_size, sample_corner_smoothness)
+
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.01)
+
+var shapes_with_various_starts_and_lengths := [
+	[0, 4, [Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN, Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT, Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT]],
+	[0, 1, [Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN, Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]],
+	[1, 2, [Vector2(1, 1), Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT, Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2(1, -1)]],
+	[2, -1, [Vector2(1, 1), Vector2(-1, 1), Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP, Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT]]
+]
+func test_add_rounded_corners___custom_start_and_length__expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__full_shape_with_resizing__expected_shape():
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	const expected_shape : PackedVector2Array = [
+		Vector2.RIGHT, Vector2(0.75, 0.75), Vector2.DOWN,
+		Vector2.DOWN, Vector2(-0.75, 0.75), Vector2.LEFT,
+		Vector2.LEFT, Vector2(-0.75, -0.75), Vector2.UP,
+		Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT
+	]
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, true, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__partial_shape_with_resizing__expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__partial_shape_with_resizing_and_extra_empties_expected_shape(p=use_parameters(shapes_with_various_starts_and_lengths)):
+	const extra_empty_spaces_amount := 5
+	const sample_corner_smoothness := 2
+	const sample_corner_size := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
+	var start_index : int = p[0]
+	var length : int = p[1]
+	var expected_shape : PackedVector2Array = p[2]
+	expected_shape.resize(expected_shape.size() + extra_empty_spaces_amount)
+	sample_shape.resize(expected_shape.size())
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
+
+func test_add_rounded_corners__non_limited_ending_slopes__expected_result():
+	const oversized_corner_size := 10
+	const sample_corner_smoothness := 1
+	const sample_start_index := 2
+	const sample_length := 1
+	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2.UP]
+	var expected_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, 1), Vector2(1, 1)]
+
+	RegularGeometry2D.add_rounded_corners(sample_shape, oversized_corner_size, sample_corner_smoothness, sample_start_index, sample_length, false)
+
+	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -1,18 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s | %s)" % [c1, c2])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+extends GutCollectionTest
 
 var various_shapes_with_corner_smoothness := [
 	[1, [Vector2.LEFT, Vector2.UP, Vector2.RIGHT, Vector2.DOWN]],

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -1,19 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
-
+extends GutCollectionTest
 
 var class_script := preload("res://addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])
@@ -118,13 +103,15 @@ func test_regenerate_polygon__holed_shape_with_drawn_arc__ends_not_equal():
 	assert_almost_ne(polygon[0], polygon[4], Vector2.ONE * 0.01, "The first and last points of the outer shape of the generated polygon.")
 	assert_almost_ne(polygon[5], polygon[9], Vector2.ONE * 0.01, "The first and last points of the inner ring of the generated polygon.")
 
-func test_get_shape_vertices__drawn_arc_PI__no_central_point(p = use_parameters([[PI], [-PI]])):
+func test_get_shape_vertices__drawn_arc_PI__no_central_point():
+	var expected := PackedVector2Array([Vector2(0, 7.07107), Vector2(-7.07107, 7.07107), Vector2(-7.07107, -7.07107), Vector2(0, -7.07107)])
 	var shape : PackedVector2Array
 
-	shape = RegularPolygon2D.get_shape_vertices(4, 10, 0, Vector2.ZERO, p[0])
+	shape = RegularPolygon2D.get_shape_vertices(4, 10, 0, Vector2.ZERO, PI)
 
 	assert_almost_ne(shape[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last element of the returned array.")
-	assert_eq(shape.size(), 4, "Size of returned array.")
+	# assert_eq(shape.size(), 4, "Size of returned array.")
+	assert_almost_eq_deep(shape, expected, Vector2.ONE * 0.001)
 
 func test_get_shape_vertices__false_central_point_when_drawn_arc_is_TAU_or_PI__no_central_point(p = use_parameters([[TAU], [PI], [-PI]])):
 	var shape : PackedVector2Array
@@ -158,23 +145,23 @@ func test_add_rounded_corners__very_small_corner_size__approximately_equal_vecto
 		assert_almost_eq(shape[index + 1], shape[index], Vector2.ONE * 0.1, "First part of corner of modified array.")
 		assert_almost_eq(shape[index + 2], shape[index], Vector2.ONE * 0.1, "Last part of corner of modified array.")
 
-func test_add_hole_to_points__do_not_close_shape__array_size_doubles():
-	var shape := PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.RIGHT])
-	var previous_size := shape.size()
+func test_add_hole_to_points__do_not_close_shape__expected_shape():
+	const sample_hole_scaler = 0.5
+	var shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10)])
+	var expected_shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10), Vector2(-6.12323e-16, -5), Vector2(-4.33013, 2.5), Vector2(4.33013, 2.5)])
 
-	RegularPolygon2D.add_hole_to_points(shape, 1, false)
-	var new_size := shape.size()
+	RegularPolygon2D.add_hole_to_points(shape, sample_hole_scaler, false)
 
-	assert_eq(new_size, 2 * previous_size, "Size of modified array, 2 * the original size.")
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.0001)
 	
-func test_add_hole_to_points__do_close_shape__array_size_doubles_plus_2():
-	var shape := PackedVector2Array([Vector2.ZERO, Vector2.ONE, Vector2.RIGHT])
-	var previous_size := shape.size()
+func test_add_hole_to_points__do_close_shape__expected_shape():
+	const sample_hole_scaler = 0.5
+	var shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10)])
+	var expected_shape := PackedVector2Array([Vector2(8.66025, 5), Vector2(-8.66025, 5), Vector2(-1.22465e-15, -10), Vector2(8.66025, 5), Vector2(4.33012, 2.5), Vector2(-6.12323e-16, -5), Vector2(-4.33013, 2.5), Vector2(4.33013, 2.5)])
 
-	RegularPolygon2D.add_hole_to_points(shape, 1, true)
-	var new_size := shape.size()
+	RegularPolygon2D.add_hole_to_points(shape, sample_hole_scaler, true)
 
-	assert_eq(new_size, 2 * previous_size + 2, "Size of modified array, 2 + 2 * the original size")
+	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.0001)
 
 var params_transform_shape := [
 	[4, 10, 100, TAU, 0, 0],

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -1,5 +1,20 @@
 extends GutTest
 
+func assert_almost_eq_deep(c1, c2, error_interval):
+	if c1.size() != c2.size():
+		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
+		return
+	
+	var has_failed := false
+	for i in c2.size():
+		if not _is_almost_eq(c1[i], c2[i], error_interval):
+			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
+			has_failed = true
+
+	if not has_failed:
+		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+
+
 var class_script := preload("res://addons/complex_shape_creation/regular_polygon_2d/regular_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])
 
@@ -161,4 +176,165 @@ func test_add_hole_to_points__do_close_shape__array_size_doubles_plus_2():
 
 	assert_eq(new_size, 2 * previous_size + 2, "Size of modified array, 2 + 2 * the original size")
 
+var params_transform_shape := [
+	[4, 10, 100, TAU, 0, 0],
+	[20, 10, 100, TAU, 0, 0],
+	[4, 100, 10, TAU, 0, 0],
+	[4, 10, 5, -PI, 0.5, 3],
+	[8, 30, 15, 2.269, 1, 2],
+]
+func test_apply_transformation__various_shape_types__almost_expected_result(p=use_parameters(params_transform_shape)):
+	const sample_rotation_amount = 2;
+	const sample_scale_amount := PI
+	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.regenerate_polygon()
 
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, false)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
+	const sample_scale_amount := 2
+	var expected_shape := PackedVector2Array([Vector2(14.1421, 14.1421), Vector2(-14.1421, 14.1421), Vector2(-14.1421, -14.1421), Vector2(14.1421, -14.1421), Vector2(14.1421, 14.1421), Vector2(3.53553, 3.53553), Vector2(3.53553, -3.53553), Vector2(-3.53553, -3.53553), Vector2(-3.53553, 3.53553), Vector2(3.53553, 3.53553)])
+	var shape := RegularPolygon2D.new()
+	shape.vertices_count = 4
+	shape.width = 15
+	shape.regenerate_polygon()
+	autoqfree(shape)
+
+	shape.apply_transformation(0, sample_scale_amount, false, false)
+
+	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
+
+func test_apply_transformation__size_change_removes_ring__shape_regenerated() -> void:
+	const sample_scale_amount := 0.5
+	var expected_shape := PackedVector2Array([Vector2(7.07107, 7.07107), Vector2(-7.07107, 7.07107), Vector2(-7.07107, -7.07107), Vector2(7.07107, -7.07107)])
+	var shape := RegularPolygon2D.new()
+	shape.vertices_count = 4
+	shape.size = 20
+	shape.width = 15
+	shape.regenerate_polygon()
+	autoqfree(shape)
+
+	shape.apply_transformation(0, sample_scale_amount, false, false)
+
+	assert_almost_eq_deep(shape.polygon, expected_shape, Vector2.ONE * 0.001)
+
+func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, false)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")
+
+func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
+	const sample_scale_amount := 2.3
+	const sample_rotation_amount := 1
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
+	shape.vertices_count = p[0]
+	shape.size = p[1]
+	shape.width = p[2]
+	shape.drawn_arc = p[3]
+	shape.corner_size = p[4]
+	shape.corner_smoothness = p[5]
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
+	var expected := RegularPolygon2D.new()
+	autoqfree(expected)
+	expected.vertices_count = p[0]
+	expected.size = p[1]
+	expected.width = p[2]
+	expected.drawn_arc = p[3]
+	expected.corner_size = p[4]
+	expected.corner_smoothness = p[5]
+	expected.regenerate_polygon()
+	shape.polygon = expected.polygon
+	expected.offset_rotation += sample_rotation_amount
+	expected.size *= sample_scale_amount
+	expected.width *= sample_scale_amount
+	expected.corner_size *= sample_scale_amount
+	expected.regenerate_polygon()
+
+	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, true)
+
+	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
+	assert_not_called(shape, "regenerate_polygon")

--- a/tests/unit_tests/test_simple_polygon_2d.gd
+++ b/tests/unit_tests/test_simple_polygon_2d.gd
@@ -9,7 +9,7 @@ func test_init__filled__variables_assigned():
 	assert_eq(shape.size, 5.0, "Property 'size'.")
 	assert_eq(shape.offset_rotation, 1.0, "Property 'offset_rotation'.")
 	assert_eq(shape.color, Color.RED, "Property 'color'.")
-	assert_eq(shape.offset_position, Vector2.ONE, "Property 'offset_position'.")
+	assert_eq(shape.offset, Vector2.ONE, "Property 'offset'.")
 	shape.queue_free()
 
 var param2 := [[2], [5], [8], [32], [100]]

--- a/tests/unit_tests/test_simple_polygon_2d.gd
+++ b/tests/unit_tests/test_simple_polygon_2d.gd
@@ -1,4 +1,4 @@
-extends GutTest
+extends GutCollectionTest
 
 func test_init__filled__variables_assigned():
 	var shape : SimplePolygon2D

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -1,18 +1,4 @@
-extends GutTest
-
-func assert_almost_eq_deep(c1, c2, error_interval):
-	if c1.size() != c2.size():
-		_fail("collections are different sizes (%s vs %s)" % [c1.size(), c2.size()])
-		return
-	
-	var has_failed := false
-	for i in c2.size():
-		if not _is_almost_eq(c1[i], c2[i], error_interval):
-			_fail("Elements at index [%s] is different (%s != %s)" % [i, c1[i], c2[i]])
-			has_failed = true
-
-	if not has_failed:
-		_pass("%s approximately matches with %s with the error interval '%s'" % [c1, c2, error_interval])
+extends GutCollectionTest
 
 var class_script := preload("res://addons/complex_shape_creation/star_polygon_2d/star_polygon_2d.gd")
 var sample_polygon := PackedVector2Array([Vector2.ONE, Vector2.RIGHT, Vector2.LEFT])
@@ -108,12 +94,12 @@ func test_get_star_vertices__drawn_arc_PI__no_central_point(p = use_parameters([
 	assert_eq(star.size(), 6, "Size of the returned array.")
 
 func test_get_star_vertices__add_central_point_false__expected_size_and_not_ZERO():
+	var expected_shape := PackedVector2Array([Vector2(-1.22465e-15, -10), Vector2(2.93893, -4.04508), Vector2(9.51057, -3.09017), Vector2(4.75528, 1.54508), Vector2(5.87785, 8.09017), Vector2(1.22465e-15, 5), Vector2(-5.87785, 8.09017), Vector2(-4.75528, 1.54508), Vector2(-6.34038, 0)])
 	var star : PackedVector2Array
 
 	star = StarPolygon2D.get_star_vertices(5, 10, 5, 0, Vector2.ZERO, PI * 3 / 2, false)
 
-	assert_almost_ne(star[-1], Vector2.ZERO, Vector2.ONE * 0.01, "The last point in the returned array.")
-	assert_eq(star.size(), 9, "Size of the returned array")
+	assert_almost_eq_deep(star, expected_shape, Vector2.ONE * 0.001)
 
 var params_transform_shape := [
 	[4, 10, 100, TAU, 0, 0],

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -13,7 +13,7 @@ func test_init__params_filled__assigned_to_vars():
 
 	star = autoqfree(StarPolygon2D.new(3, 5.0, 1.0, 1.0, Color.RED, Vector2.ONE, 1.0, 1.0, 1.0, 1))
 
-	assert_eq(star.point_count, 3, "Property 'point_count'.")
+	assert_eq(star.vertices_count, 3, "Property 'vertices_count'.")
 	assert_eq(star.size, 5.0, "Property 'size'.")
 	assert_eq(star.inner_size, 1.0, "Property 'inner_size'.")
 	assert_eq(star.offset_rotation, 1.0, "Property 'offset_rotation'.")
@@ -44,13 +44,13 @@ func test_init__polygon_empty__queue_not_blocked():
 
 func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : StarPolygon2D = partial_double(class_script).new()
-	stub(shape, "regenerate_polygon").to_do_nothing()
+	stub(shape, "regenerate").to_do_nothing()
 	shape.polygon = sample_polygon
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
 
 	shape._enter_tree()
 
-	assert_not_called(shape, "regenerate_polygon") # does not accept a custom message.
+	assert_not_called(shape, "regenerate") # does not accept a custom message.
 
 func test_enter_tree__not_not_queued__now_not_queued(p= use_parameters([StarPolygon2D._IS_QUEUED, StarPolygon2D._BLOCK_QUEUE])):
 	var shape : StarPolygon2D = partial_double(class_script).new()
@@ -66,7 +66,7 @@ func test_pre_redraw__not_queued__is_queued():
 	star.polygon = sample_polygon
 	star._queue_status = StarPolygon2D._NOT_QUEUED
 
-	star._pre_redraw()
+	star.queue_regenerate()
 
 	assert_eq(star._queue_status, StarPolygon2D._IS_QUEUED, "Property '_queue_status' should be '_IS_QUEUED' (1).")
 
@@ -77,7 +77,7 @@ func test_queue_regenerate__in_tree__delayed_shape_filled():
 	stub(star, "_enter_tree").to_do_nothing()
 	add_child(star)
 
-	star._pre_redraw()
+	star.queue_regenerate()
 
 	assert_true(star.polygon.is_empty(), "Variable 'polygon' should still be an empty array.")
 	await wait_for_signal(get_tree().process_frame, 10)
@@ -114,7 +114,7 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	assert(p[2] >= 0 and p[0] != 2, "param does not have the node use 'polygon'.")
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -124,67 +124,67 @@ func test_apply_transformation__various_shape_types__almost_expected_result(p=us
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__size_change_creates_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 3
 	var expected := StarPolygon2D.new()
-	expected.point_count = 4
+	expected.vertices_count = 4
 	expected.width = 15
-	expected.regenerate_polygon()
+	expected.regenerate()
 	autoqfree(expected)
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = 4
+	shape.vertices_count = 4
 	shape.width = 15
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	shape.polygon = expected.polygon
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(0, sample_scale_amount, false, false)
 
-	assert_called(shape, "regenerate_polygon")
+	assert_called(shape, "regenerate")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
 func test_apply_transformation__size_change_removes_ring__shape_regenerated() -> void:
 	const sample_scale_amount := 0.2
 	var expected := StarPolygon2D.new()
-	expected.point_count = 4
+	expected.vertices_count = 4
 	expected.width = 5
-	expected.regenerate_polygon()
+	expected.regenerate()
 	autoqfree(expected)
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = 4
+	shape.vertices_count = 4
 	shape.width = 5
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	shape.polygon = expected.polygon
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(0, sample_scale_amount, false, false)
 
-	assert_called(shape, "regenerate_polygon")
+	assert_called(shape, "regenerate")
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
 
 func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(params_transform_shape)):
@@ -192,7 +192,7 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -202,32 +202,32 @@ func test_apply_transformation__width_scaled__expected_shape(p=use_parameters(pa
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.width *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, false)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
 	const sample_scale_amount := 2.3
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -237,32 +237,32 @@ func test_apply_transformation__corner_size_scaled__expected_shape(p=use_paramet
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.corner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, false, true)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")
 
 func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=use_parameters(params_transform_shape)):
 	const sample_scale_amount := 2.3
 	const sample_rotation_amount := 1
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
-	shape.point_count = p[0]
+	shape.vertices_count = p[0]
 	shape.size = p[1]
 	shape.inner_size = p[1] / 2.0
 	shape.width = p[2]
@@ -272,23 +272,23 @@ func test_apply_transformation__width_and_corner_size_scaled__expected_shape(p=u
 	shape._queue_status = StarPolygon2D._NOT_QUEUED
 	var expected := StarPolygon2D.new()
 	autoqfree(expected)
-	expected.point_count = p[0]
+	expected.vertices_count = p[0]
 	expected.size = p[1]
 	expected.inner_size = p[1] / 2.0
 	expected.width = p[2]
 	expected.drawn_arc = p[3]
 	expected.corner_size = p[4]
 	expected.corner_smoothness = p[5]
-	expected.regenerate_polygon()
+	expected.regenerate()
 	shape.polygon = expected.polygon
 	expected.offset_rotation += sample_rotation_amount
 	expected.size *= sample_scale_amount
 	expected.inner_size *= sample_scale_amount
 	expected.width *= sample_scale_amount
 	expected.corner_size *= sample_scale_amount
-	expected.regenerate_polygon()
+	expected.regenerate()
 
 	shape.apply_transformation(sample_rotation_amount, sample_scale_amount, true, true)
 
 	assert_almost_eq_deep(shape.polygon, expected.polygon, Vector2.ONE * 0.001)
-	assert_not_called(shape, "regenerate_polygon")
+	assert_not_called(shape, "regenerate")


### PR DESCRIPTION
## Changes
### Major
- Added gui handlers, so the nodes can now be edited graphically. Currently, only the handler responsible for `size` and `offset_rotation` is implemented. (#66 #69)
- Added method `apply_transformation`, which in most cases directly edits the current points of the shape. Compared to regenerating the shape, it is generally faster. (#55)
- Property names have been changed to make them consistent across nodes. The old names still remain for compatibility reasons, and will be removed in the next major release. (#60 #61)

### Minor
- The beginnings of `RegularGeometry2D` has been added, holding some static functions that have been added or altered since its addition. It is still very incomplete (even its name isn't final), and so does not have C# interop. (#53)

### Bugs
- Fixed inconsistencies in the width of rounded corners of a ringed shape when it is a complete ring and when it is an open ring (`drawn_arc` isn't ±TAU) (#54)
- Fixed normal generated circles being rotated the opposite way. (#67)

## Internal Changes
- Added copy of the license at the root level, and updated README accordingly. (#68 #71)
- Unit Tests have been improved. They now inherit from a custom class which adds a custom assert method for comparing deep equality approximately and a helper method for creating arrays of `Vector2s` (#59)