### PR TITLE
Geometry renaming and c# Interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ addons.zip
 /testing/
 
 # ignore .DS_Stores
-.DS_Store
-*/.DS_Store
+**/.DS_Store
+
 .vscode
 .idea
+**/**.sln.DotSettings.user

--- a/addons/simplified_shape_creation/SimpleGeometry2D.cs
+++ b/addons/simplified_shape_creation/SimpleGeometry2D.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Godot;
+
+namespace SimplifiedShapeCreation;
+
+public static class SimpleGeometry2D
+{
+    private static readonly ScriptLoader Loader = new();
+    private class ScriptLoader : Lazy<GodotObject>, IDisposable
+    {
+        private static readonly GDScript Script = GD.Load<GDScript>("res://addons/simplified_shape_creation/simple_geometry2d.gd");
+
+        public ScriptLoader() : base(Factory, LazyThreadSafetyMode.ExecutionAndPublication)
+        {
+        }
+
+        private static GodotObject Factory()
+        {
+            if (Engine.GetMainLoop() is SceneTree tree)
+            {
+                tree.Root.TreeExiting += SimpleGeometry2D.Dispose;
+            }
+            return Script.New(true).AsGodotObject();
+        }
+
+        ~ScriptLoader()
+        {
+            Dispose();
+        }
+
+        [SuppressMessage("ReSharper", "MemberHidesStaticFromOuterClass")]
+        public void Dispose()
+        {
+            if (GodotObject.IsInstanceValid(Value))
+            {
+                Value.Free();
+            }
+        }
+    }
+
+    public static void Dispose()
+    {
+        Loader.Dispose();
+    }
+
+    /// <summary>
+    /// Cached <see cref="StringName"/>s for most of the methods contained in this class, for fast lookup.
+    /// </summary>
+    [SuppressMessage("ReSharper", "MemberHidesStaticFromOuterClass")]
+    public static class MethodName
+    {
+        public static readonly StringName CreateShape = new("create_shape");
+        public static readonly StringName AddRing = new("add_ring");
+        public static readonly StringName AddRoundedCorners = new("add_rounded_corners");
+    }
+
+    public static Vector2[] CreateShape(int verticesCount, long[] sizes, double offsetRotation = 0d,
+        Vector2 offsetPosition = default, double arcStart = 0d, double arcEnd = Math.Tau, bool addCentralPoint = true)
+    {
+        Debug.Assert(Loader.Value.HasMethod(MethodName.CreateShape));
+        return Loader.Value.Call(MethodName.CreateShape, verticesCount, sizes, offsetRotation, offsetPosition,
+            arcStart, arcEnd, addCentralPoint).AsVector2Array();
+    }
+
+
+
+    public static Vector2[] AddRing(Vector2[] shape, double lengthProportion, Vector2 shapeCenter = default, bool closeRing = true)
+    {
+        Debug.Assert(Loader.Value.HasMethod(MethodName.AddRing));
+        return Loader.Value.Call(MethodName.AddRing, shape, lengthProportion, shapeCenter, closeRing).AsVector2Array();
+    }
+
+    // static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
+    // start_index := 0, length := -1, limit_ending_slopes := true, original_array_size := 0) -> void:
+    public static Vector2[] AddRoundedCorners(Vector2[] shape, double cornerSize, long cornerSmoothness)
+    {
+        Debug.Assert(Loader.Value.HasMethod(MethodName.AddRoundedCorners));
+        return Loader.Value.Call(MethodName.AddRoundedCorners, shape, cornerSize, cornerSmoothness).AsVector2Array();
+    }
+}

--- a/addons/simplified_shape_creation/SimpleGeometry2D.cs
+++ b/addons/simplified_shape_creation/SimpleGeometry2D.cs
@@ -6,6 +6,13 @@ using Godot;
 
 namespace SimplifiedShapeCreation;
 
+/// <summary>Holds methods for creating and modifying shapes.</summary>
+/// <remarks>
+/// In order to interop with the gdscript equivalent methods, an instance of the <see cref="GDScript"/> has to be created,
+/// as well as be manually freed at the end of application lifetime via <see cref="Dispose"/>.
+/// <br/><br/>If the <see cref="MainLoop"/> is implemented as a <see cref="SceneTree"/>, <see cref="Dispose"/> will
+/// automatically be called when the root <see cref="Window"/> node is exiting the tree.
+/// </remarks>
 public static class SimpleGeometry2D
 {
     private static readonly ScriptLoader Loader = new();
@@ -41,22 +48,38 @@ public static class SimpleGeometry2D
         }
     }
 
+    /// <summary>
+    /// <see cref="GodotObject.Free"/>s the gdscript instance this class interops with to call
+    /// the other methods, if it hasn't been already.
+    /// </summary>
     public static void Dispose()
     {
         Loader.Dispose();
     }
 
     /// <summary>
-    /// Cached <see cref="StringName"/>s for most of the methods contained in this class, for fast lookup.
+    /// Cached <see cref="StringName"/>s for the methods contained in this class, for fast lookup.
     /// </summary>
     [SuppressMessage("ReSharper", "MemberHidesStaticFromOuterClass")]
     public static class MethodName
     {
+        public static readonly StringName Dispose = new(nameof(SimpleGeometry2D.Dispose));
         public static readonly StringName CreateShape = new("create_shape");
         public static readonly StringName AddRing = new("add_ring");
         public static readonly StringName AddRoundedCorners = new("add_rounded_corners");
     }
 
+    /// <summary>
+    /// Creates and returns a <see cref="T:Vector2[]"/> describing the shape specified by the parameters.
+    /// </summary>
+    /// <param name="verticesCount">The number of points on the base shape. If it is a value of <c>1</c>, a value of <c>32</c> is used instead.</param>
+    /// <param name="sizes">Determines the length of each point from the center of the base shape, being repeatedly iterated through to get the length for each corner.</param>
+    /// <param name="offsetRotation">The amount in radians to rotate the shape.</param>
+    /// <param name="offsetPosition">The amount to shift the shape.</param>
+    /// <param name="arcStart">The starting angle of the arc out of the base shape that is cut out and returned, in radians.</param>
+    /// <param name="arcEnd">The ending angle of the arc out of the base shape that is cut out and returned, in radians.</param>
+    /// <param name="addCentralPoint">If <c>true</c>, adds a center point to the shape. It is automatically false if the arc of the shape is a complete circle.</param>
+    /// <returns>A <see cref="T:Vector2[]"/> describing the shape specified by the parameters.</returns>
     public static Vector2[] CreateShape(int verticesCount, long[] sizes, double offsetRotation = 0d,
         Vector2 offsetPosition = default, double arcStart = 0d, double arcEnd = Math.Tau, bool addCentralPoint = true)
     {
@@ -65,16 +88,28 @@ public static class SimpleGeometry2D
             arcStart, arcEnd, addCentralPoint).AsVector2Array();
     }
 
-
-
+    /// <summary>
+    /// Returns a modified copy of <paramref name="shape"/>, adding a duplicate ring of points.
+    /// </summary>
+    /// <param name="shape">The base shape.</param>
+    /// <param name="lengthProportion">The proportion of the distance of the original points which the new points are placed at, relative to the <paramref name="shapeCenter"/>.</param>
+    /// <param name="shapeCenter">The center of the shape.</param>
+    /// <param name="closeRing">If true, the first point is also appended to the end before adding the ring.</param>
+    /// <returns>A <see cref="T:Vector2[]"/>, representing the shape of <paramref name="shape"/> with an added ring.</returns>
     public static Vector2[] AddRing(Vector2[] shape, double lengthProportion, Vector2 shapeCenter = default, bool closeRing = true)
     {
         Debug.Assert(Loader.Value.HasMethod(MethodName.AddRing));
         return Loader.Value.Call(MethodName.AddRing, shape, lengthProportion, shapeCenter, closeRing).AsVector2Array();
     }
 
-    // static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
-    // start_index := 0, length := -1, limit_ending_slopes := true, original_array_size := 0) -> void:
+    /// <summary>
+    /// Returns a modified copy of <paramref name="shape"/> with rounded corners.
+    /// </summary>
+    /// <remarks>The method uses quadratic Bézier curves to place the points on the rounded corner.</remarks>
+    /// <param name="shape">The base shape.</param>
+    /// <param name="cornerSize">The distance along the edge where the smoothed corner will start from.</param>
+    /// <param name="cornerSmoothness">How many lines are in each corner.</param>
+    /// <returns>A <see cref="T:Vector2[]"/>, representing the shape of <paramref name="shape"/> with rounded corners.</returns>
     public static Vector2[] AddRoundedCorners(Vector2[] shape, double cornerSize, long cornerSmoothness)
     {
         Debug.Assert(Loader.Value.HasMethod(MethodName.AddRoundedCorners));

--- a/addons/simplified_shape_creation/gui_handlers/base_handler.gd
+++ b/addons/simplified_shape_creation/gui_handlers/base_handler.gd
@@ -120,7 +120,7 @@ func _clamp_position() -> void:
 func clamp_straight_line() -> Vector2:
 	var allowed_line := _old_position - _origin
 	var inverse_line := Vector2(-allowed_line.y, allowed_line.x)
-	var a := RegularGeometry2D._find_intersection(position, inverse_line, _origin, allowed_line)
+	var a :=            SimpleGeometry2d._find_intersection(position, inverse_line, _origin, allowed_line)
 	return position + inverse_line * a
 
 func clamp_circle_radius() -> Vector2:

--- a/addons/simplified_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/simplified_shape_creation/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -121,7 +121,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 			shape.points = points
 			return
 
-		RegularGeometry2D.apply_transformation(points, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
+		SimpleGeometry2d.apply_transformation(points, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
 		shape.points = points
 		return
 
@@ -134,19 +134,19 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	if is_line:
 		if is_zero_approx(width):
 			if scale_corner_size and has_rounded_corners:
-				RegularGeometry2D.apply_transformation(segments, rotation, scale)
+				SimpleGeometry2d.apply_transformation(segments, rotation, scale)
 				shape.segments = segments
 				return 
 			
 			segments[0] *= scale
 			segments[-1] *= scale
-			RegularGeometry2D.apply_transformation(segments, rotation, 1)
+			SimpleGeometry2d.apply_transformation(segments, rotation, 1)
 			shape.segments = segments
 			return
 
 		
 		if scale_width and (scale_corner_size or not has_rounded_corners):
-			RegularGeometry2D.apply_transformation(segments, rotation, scale)
+			SimpleGeometry2d.apply_transformation(segments, rotation, scale)
 			shape.segments = segments
 			return 
 			
@@ -155,7 +155,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 			regenerate()
 			return
 
-		RegularGeometry2D.apply_transformation(segments, rotation, 1)
+		SimpleGeometry2d.apply_transformation(segments, rotation, 1)
 
 		# extend segments
 		if not has_rounded_corners:
@@ -221,7 +221,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 			segments[i - 1] = segments[i]
 		segments[-2] = temp
 
-	RegularGeometry2D.apply_transformation(segments, rotation, scale, is_ringed_shape, points_per_corner, scale_width, scale_corner_size)
+	SimpleGeometry2d.apply_transformation(segments, rotation, scale, is_ringed_shape, points_per_corner, scale_width, scale_corner_size)
 
 	if offset_points:
 		var temp := segments[0]

--- a/addons/simplified_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/simplified_shape_creation/regular_polygon_2d/regular_polygon_2d.gd
@@ -82,7 +82,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	points_per_corner += 1
 	
 	var shape := polygon
-	RegularGeometry2D.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
+	SimpleGeometry2d.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
 	polygon = shape
 
 
@@ -436,19 +436,19 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 		# temp points to have corners rounded to its correct neighbours.
 		var temp_point := points[0]
 		points[0] = points[-functional_length]
-		RegularGeometry2D.add_rounded_corners(points, corner_size, corner_smoothness, functional_length + 2, functional_length)
+		SimpleGeometry2d.add_rounded_corners(points, corner_size, corner_smoothness, functional_length + 2, functional_length)
 		points[0] = temp_point
 
 		temp_point = points[-1]
 		points[-1] = points[functional_length - 1]
-		RegularGeometry2D.add_rounded_corners(points, corner_size, corner_smoothness, 0, functional_length)
+		SimpleGeometry2d.add_rounded_corners(points, corner_size, corner_smoothness, 0, functional_length)
 		points[-1] = temp_point
 
 		points[functional_length * (corner_smoothness + 1)] = points[0]
 		points[functional_length * (corner_smoothness + 1) + 1] = points[-1]
 		return
 	
-	RegularGeometry2D.add_rounded_corners(points, corner_size, corner_smoothness)
+	SimpleGeometry2d.add_rounded_corners(points, corner_size, corner_smoothness)
 
 # Returns the point at the given [param t] on the Bézier curve with the given [param start], [param end], and single [param control] point.
 ## [b][color=red]Warning[/color][/b]: This method is not meant to be used outside the class, and will be changed/made private in the future.

--- a/addons/simplified_shape_creation/simple_geometry2d.gd
+++ b/addons/simplified_shape_creation/simple_geometry2d.gd
@@ -3,9 +3,10 @@ class_name SimpleGeometry2d
 
 ## Holds methods for creating and modifying shapes.
 
-func _init():
-	printerr("This class is meant to be a singleton, and cannot be instantiated")
-	self.free()
+func _init(instantiated_from_cs_singleton : bool):
+	if !instantiated_from_cs_singleton:
+		printerr("This class is meant to be a singleton, and cannot be instantiated")
+		self.free()
 
 # gets the point on a unit circle for the specified rotation.
 static func _circle_point(rotation : float) -> Vector2:
@@ -97,7 +98,7 @@ static func add_ring(shape: PackedVector2Array, length_proportion: float, shape_
 ## [param original_array_size], when used, indicates that the array has already been resized, so the method should add points into the empty space.
 ## This parameter specifies the part of the array that is currently used.
 static func add_rounded_corners(points : PackedVector2Array, corner_size : float, corner_smoothness : int,
-	start_index := 0, length := -1, limit_ending_slopes := true, original_array_size := 0) -> void:
+	start_index := 0, length := -1, limit_ending_slopes := true, original_array_size := 0) -> PackedVector2Array:
 	# argument prep 
 	var corner_size_squared := corner_size ** 2
 	var points_per_corner := corner_smoothness + 1
@@ -186,6 +187,8 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 		# end, prep for next loop.
 		previous_point = current_point
 		current_point = next_point
+
+	return points
 
 static func _quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)

--- a/addons/simplified_shape_creation/simple_geometry2d.gd
+++ b/addons/simplified_shape_creation/simple_geometry2d.gd
@@ -1,5 +1,5 @@
 extends Object
-class_name RegularGeometry2D
+class_name SimpleGeometry2d
 
 ## Holds methods for creating and modifying shapes.
 

--- a/addons/simplified_shape_creation/simple_geometry2d.gd
+++ b/addons/simplified_shape_creation/simple_geometry2d.gd
@@ -25,8 +25,8 @@ static func _find_intersection(point1 : Vector2, slope1 : Vector2, point2: Vecto
 ## [br][br]
 ## [param vertices_count] determines the number of points on the base shape. If a value of [code]1[/code] is used,
 ## A value of [code]32[/code] is used instead.
-## [param sizes] determines the length of each point from the center of the base shape, being repeatedly looped through
-## to get that length.
+## [param sizes] determines the length of each point from the center of the base shape, being repeatedly iterated through
+## to get the length for each corner.
 ## [param arc_start] and [param arc_end] determine the arc out of that base shape that is cut out and returned, in radians.
 ## [param add_central_point] determines whether a central point is added to the shape. It is automatically set to [code]false[/code]
 ## if the arc of the shape is a complete circle.

--- a/addons/simplified_shape_creation/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/simplified_shape_creation/star_polygon_2d/star_polygon_2d.gd
@@ -100,7 +100,7 @@ func apply_transformation(rotation : float, scale : float, scale_width := true, 
 	points_per_corner += 1
 	
 	var shape := polygon
-	RegularGeometry2D.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
+	SimpleGeometry2d.apply_transformation(shape, rotation, scale, 0 < width and width < size, points_per_corner, scale_width, scale_corner_size)
 	polygon = shape
 
 @export_group("complex")

--- a/tests/c#_interop/SimpleGeometry2DTests.cs
+++ b/tests/c#_interop/SimpleGeometry2DTests.cs
@@ -1,0 +1,46 @@
+using Chickensoft.GoDotTest;
+using Godot;
+using Shouldly;
+
+namespace SimplifiedShapeCreation.Tests;
+
+public class SimpleGeometry2DTests : TestClass
+{
+    public SimpleGeometry2DTests(Node testScene) : base(testScene)
+    {
+    }
+
+    [Test]
+    public void CreateShape_SampleCall_ExpectedReturnValue()
+    {
+        Vector2[] result = SimpleGeometry2D.CreateShape(4, new[]{1L});
+
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(4);
+    }
+
+    [Test]
+    public void AddRing_SampleCall_ExpectedReturnValue()
+    {
+        Vector2[] shape = new[] { Vector2.Up, Vector2.Down };
+        float lengthProportion = 0.5f;
+
+        Vector2[] result = SimpleGeometry2D.AddRing(shape, lengthProportion);
+
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(6);
+    }
+
+    [Test]
+    public void AddRoundedCorners_SampleCall_ExpectedReturnValue()
+    {
+        Vector2[] shape = new[] { Vector2.Left, Vector2.Up, Vector2.Right };
+        float cornerSize = 0.1f;
+        int cornerSmoothness = 2;
+
+        Vector2[] result = SimpleGeometry2D.AddRoundedCorners(shape, cornerSize, cornerSmoothness);
+
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(9);
+    }
+}

--- a/tests/unit_tests/regular_geometry/test_add_ring.gd
+++ b/tests/unit_tests/regular_geometry/test_add_ring.gd
@@ -10,6 +10,6 @@ func test_add_ring__various_inputs__expected_outputs(p=use_parameters([
 	var close_ring : bool = p[3]
 	var expected_shape : PackedVector2Array = p[4]
 
-	var actual_shape := RegularGeometry2D.add_ring(shape, length_proportion, shape_center, close_ring)
+	var actual_shape := SimpleGeometry2d.add_ring(shape, length_proportion, shape_center, close_ring)
 
 	assert_almost_eq_deep(actual_shape, expected_shape, Vector2.ONE * 0.001)

--- a/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
+++ b/tests/unit_tests/regular_geometry/test_add_rounded_corners.gd
@@ -11,7 +11,7 @@ func test_add_rounded_corners__various_shapes_with_0_corner_size__expected_shape
 	var original := PackedVector2Array(shape)
 	var expected_size := shape.size() * (corner_smoothness + 1)
 
-	RegularGeometry2D.add_rounded_corners(shape, 0, corner_smoothness)
+	SimpleGeometry2d.add_rounded_corners(shape, 0, corner_smoothness)
 
 	assert_eq(shape.size(), expected_size, "Size of modified array should be %s but was %s" % [expected_size, shape.size()])
 	for i in original.size():
@@ -29,7 +29,7 @@ func test_add_rounded_corners__oversized_corner_size__corner_size_limited():
 		Vector2.UP, Vector2(0.75, -0.75), Vector2.RIGHT
 	]
 
-	RegularGeometry2D.add_rounded_corners(shape, oversized_corner_size, sample_corner_smoothness)
+	SimpleGeometry2d.add_rounded_corners(shape, oversized_corner_size, sample_corner_smoothness)
 
 	assert_almost_eq_deep(shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -47,7 +47,7 @@ func test_add_rounded_corners___custom_start_and_length__expected_shape(p=use_pa
 	var length : int = p[1]
 	var expected_shape : PackedVector2Array = p[2]
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length)
+	SimpleGeometry2d.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -63,7 +63,7 @@ func test_add_rounded_corners__full_shape_with_resizing__expected_shape():
 	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, -1), Vector2(1, -1)]
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, true, 4)
+	SimpleGeometry2d.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, 0, -1, true, 4)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -76,7 +76,7 @@ func test_add_rounded_corners__partial_shape_with_resizing__expected_shape(p=use
 	var expected_shape : PackedVector2Array = p[2]
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
+	SimpleGeometry2d.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -91,7 +91,7 @@ func test_add_rounded_corners__partial_shape_with_resizing_and_extra_empties_exp
 	expected_shape.resize(expected_shape.size() + extra_empty_spaces_amount)
 	sample_shape.resize(expected_shape.size())
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
+	SimpleGeometry2d.add_rounded_corners(sample_shape, sample_corner_size, sample_corner_smoothness, start_index, length, true, 4)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)
 
@@ -103,6 +103,6 @@ func test_add_rounded_corners__non_limited_ending_slopes__expected_result():
 	var sample_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2.UP]
 	var expected_shape : PackedVector2Array = [Vector2(1, 1), Vector2(-1, 1), Vector2(-1, 1), Vector2(1, 1)]
 
-	RegularGeometry2D.add_rounded_corners(sample_shape, oversized_corner_size, sample_corner_smoothness, sample_start_index, sample_length, false)
+	SimpleGeometry2d.add_rounded_corners(sample_shape, oversized_corner_size, sample_corner_smoothness, sample_start_index, sample_length, false)
 
 	assert_almost_eq_deep(sample_shape, expected_shape, Vector2.ONE * 0.01)

--- a/tests/unit_tests/regular_geometry/test_create_shape.gd
+++ b/tests/unit_tests/regular_geometry/test_create_shape.gd
@@ -17,6 +17,6 @@ func test_create_shape__various_inputs__expected_outputs(p=use_parameters([
 	var add_central_point : bool = p[6]
 	var expected_shape : PackedVector2Array = p[7]
 
-	var actual_shape := RegularGeometry2D.create_shape(vertices_count, sizes, offset_rotation, offset_position, arc_start, arc_end, add_central_point)
+	var actual_shape := SimpleGeometry2d.create_shape(vertices_count, sizes, offset_rotation, offset_position, arc_start, arc_end, add_central_point)
 
 	assert_almost_eq_deep(actual_shape, expected_shape, Vector2.ONE * 0.01)


### PR DESCRIPTION
Renamed `RegularGeometry2D` to `SimpleGeometry2D`, and added c# interop to most methods implemented there.